### PR TITLE
feat: separate simulation and verification nonce handling

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -48,29 +48,25 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: 'simulation-loading',
           builder: (context, state) {
-            final extra = state.extra as (SafeAccount, SafeTransaction, BigInt);
+            final extra = state.extra as (SafeAccount, SafeTransaction);
             final SafeAccount safeAccount = extra.$1;
             final SafeTransaction safeTx = extra.$2;
-            final BigInt nonce = extra.$3;
             return SimulationLoadingScreen(
               safeAccount: safeAccount,
               transaction: safeTx,
-              nonce: nonce,
             );
           },
         ),
         GoRoute(
           path: 'simulation-results',
           builder: (context, state) {
-            final extra = state.extra as (SafeAccount, SafeTransaction, BigInt, SimulationResult);
+            final extra = state.extra as (SafeAccount, SafeTransaction, SimulationResult);
             final SafeAccount safeAccount = extra.$1;
             final SafeTransaction safeTx = extra.$2;
-            final BigInt latestNonce = extra.$3;
-            final SimulationResult simulationResult = extra.$4;
+            final SimulationResult simulationResult = extra.$3;
             return SafeTxSimulationScreen(
               safeAccount: safeAccount,
               transaction: safeTx,
-              nonce: latestNonce,
               simulationResult: simulationResult,
             );
           },
@@ -78,28 +74,24 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: 'hashes',
           builder: (context, state) {
-            final extra = state.extra as (SafeAccount, SafeTransaction, BigInt?);
+            final extra = state.extra as (SafeAccount, SafeTransaction);
             final SafeAccount safeAccount = extra.$1;
             final SafeTransaction safeTx = extra.$2;
-            final BigInt? latestNonce = extra.$3;
             return SafeHashesVerifyScreen(
               safeAccount: safeAccount,
               safeTransaction: safeTx,
-              latestNonce: latestNonce,
             );
           },
         ),
         GoRoute(
           path: 'ledger',
           builder: (context, state) {
-            final extra = state.extra as (SafeAccount, SafeTransaction, BigInt);
+            final extra = state.extra as (SafeAccount, SafeTransaction);
             final SafeAccount safeAccount = extra.$1;
             final SafeTransaction safeTx = extra.$2;
-            final BigInt nonce = extra.$3;
             return SafeLedgerVerifyScreen(
               safeAccount: safeAccount,
               safeTransaction: safeTx,
-              nonce: nonce,
             );
           },
         ),

--- a/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
+++ b/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
@@ -8,13 +8,11 @@ import 'package:safe_verify/shared/models/safe_account_model.dart';
 import 'package:safe_verify/shared/models/safe_transaction_model.dart';
 
 class SafeHashesVerifyScreen extends StatefulWidget {
-  final BigInt? latestNonce;
   final SafeAccount safeAccount;
   final SafeTransaction safeTransaction;
 
   const SafeHashesVerifyScreen({
     super.key,
-    this.latestNonce,
     required this.safeAccount,
     required this.safeTransaction,
   });
@@ -28,7 +26,7 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
 
   @override
   void initState() {
-    nonce = widget.latestNonce;
+    nonce = widget.safeTransaction.nonce;
     super.initState();
   }
 
@@ -46,14 +44,14 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     _NonceControl(
-                      latestNonce: widget.latestNonce,
-                      onChange: (_nonce) => setState(() => nonce = _nonce),
+                      initialValue: widget.safeTransaction.nonce,
+                      latestNonce: widget.safeTransaction.latestNonce,
+                      onChange: (_nonce) => setState(() => widget.safeTransaction.nonce = _nonce),
                     ),
                     const SizedBox(height: 16),
                     _AccountDetailsCard(safeAccount: widget.safeAccount),
                     const SizedBox(height: 16),
                     _TransactionHashesCard(
-                      nonce: nonce,
                       safeAccount: widget.safeAccount,
                       safeTransaction: widget.safeTransaction,
                     ),
@@ -75,7 +73,7 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
                           onPressed: () {
                             GoRouter.of(context).push(
                               "/verify-transaction/ledger",
-                              extra: (widget.safeAccount, widget.safeTransaction, nonce!)
+                              extra: (widget.safeAccount, widget.safeTransaction)
                             );
                           },
                           child: const Text('Verify Ledger Screens'),
@@ -207,12 +205,10 @@ class _AccountDetailsCardState extends State<_AccountDetailsCard>
 }
 
 class _TransactionHashesCard extends StatefulWidget {
-  final BigInt? nonce;
   final SafeAccount safeAccount;
   final SafeTransaction safeTransaction;
 
   const _TransactionHashesCard({
-    this.nonce,
     required this.safeAccount,
     required this.safeTransaction,
   });
@@ -231,7 +227,7 @@ class _TransactionHashesCardState extends State<_TransactionHashesCard> {
 
   @override
   Widget build(BuildContext context) {
-    widget.safeTransaction.calculateHashes(widget.safeAccount, nonce: widget.nonce).then((result) {
+    widget.safeTransaction.calculateHashes(widget.safeAccount).then((result) {
       if (!mounted) return;
       setState(() => _hashes = result);
     });
@@ -528,10 +524,11 @@ class _TransactionJsonCardState extends State<_TransactionJsonCard> with SingleT
 }
 
 class _NonceControl extends StatefulWidget {
+  final BigInt? initialValue;
   final BigInt? latestNonce;
   final Function(BigInt) onChange;
 
-  const _NonceControl({this.latestNonce, required this.onChange});
+  const _NonceControl({this.initialValue, this.latestNonce, required this.onChange});
 
   @override
   State<_NonceControl> createState() => _NonceControlState();
@@ -545,7 +542,7 @@ class _NonceControlState extends State<_NonceControl> {
   @override
   void initState() {
     super.initState();
-    _nonce = widget.latestNonce ?? BigInt.zero;
+    _nonce = widget.initialValue ?? BigInt.zero;
   }
 
   @override

--- a/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
+++ b/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
@@ -22,11 +22,9 @@ class SafeHashesVerifyScreen extends StatefulWidget {
 }
 
 class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
-  BigInt? nonce;
 
   @override
   void initState() {
-    nonce = widget.safeTransaction.nonce;
     super.initState();
   }
 

--- a/lib/features/verify_safe_transaction/ledger_verification/safe_ledger_verify_screen.dart
+++ b/lib/features/verify_safe_transaction/ledger_verification/safe_ledger_verify_screen.dart
@@ -11,8 +11,7 @@ import 'package:version/version.dart';
 class SafeLedgerVerifyScreen extends StatefulWidget {
   final SafeAccount safeAccount;
   final SafeTransaction safeTransaction;
-  final BigInt nonce;
-  const SafeLedgerVerifyScreen({super.key, required this.safeAccount, required this.safeTransaction, required this.nonce});
+  const SafeLedgerVerifyScreen({super.key, required this.safeAccount, required this.safeTransaction});
 
   @override
   State<SafeLedgerVerifyScreen> createState() => _SafeLedgerVerifyScreenState();
@@ -62,7 +61,6 @@ class _SafeLedgerVerifyScreenState extends State<SafeLedgerVerifyScreen> {
             Version.parse("0.0.0"), // todo add actual version
             widget.safeAccount,
             widget.safeTransaction,
-            widget.nonce
           ),
           builder: (BuildContext context, AsyncSnapshot snapshot) {
             if (snapshot.connectionState != ConnectionState.done){

--- a/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
+++ b/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
@@ -69,12 +69,18 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
 
   void _onSubmit() async {
     var cancelLoad = BotToast.showLoading();
-    var latestNonce = await widget.safeAccount.getNonce();
+    final (success, error) = await safeTransaction!.ensureNonce(widget.safeAccount);
     cancelLoad();
     if (!mounted) return;
+
+    if (!success) {
+      BotToast.showText(text: error);
+      return;
+    }
+
     GoRouter.of(context).push(
       "/verify-transaction/simulation-loading",
-      extra: (widget.safeAccount, safeTransaction!, latestNonce),
+      extra: (widget.safeAccount, safeTransaction!),
     );
   }
 

--- a/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
@@ -149,8 +149,22 @@ class _SafeTxSimulationScreenState extends State<SafeTxSimulationScreen> {
                       Icon(Icons.warning, color: Colors.orange),
                       const SizedBox(width: 12),
                       Expanded(
-                        child: Text(
-                          'This simulation runs against the account\'s current nonce rather than the nonce supplied in the transaction data. This allows the simulation to bypass the on-chain nonce verification check.',
+                        child: Text.rich(
+                          TextSpan(
+                            children: [
+                              TextSpan(text: 'Nonce Mismatch: '),
+                              TextSpan(
+                                text: 'Transaction nonce (${widget.transaction.nonce}) ',
+                                style: TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                              TextSpan(text: 'differs from current on-chain nonce '),
+                              TextSpan(
+                                text: '(${widget.transaction.latestNonce})',
+                                style: TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                              TextSpan(text: '. Simulation uses the current nonce to bypass on-chain checks.'),
+                            ],
+                          ),
                           style: TextStyle(color: Colors.orange.shade900),
                         ),
                       ),

--- a/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
@@ -23,14 +23,12 @@ import 'package:wallet/wallet.dart';
 class SafeTxSimulationScreen extends StatefulWidget {
   final SafeAccount safeAccount;
   final SafeTransaction transaction;
-  final BigInt nonce;
   final SimulationResult simulationResult;
 
   const SafeTxSimulationScreen({
     super.key,
     required this.safeAccount,
     required this.transaction,
-    required this.nonce,
     required this.simulationResult,
   });
 
@@ -110,7 +108,7 @@ class _SafeTxSimulationScreenState extends State<SafeTxSimulationScreen> {
                 onPressed: () {
                   GoRouter.of(context).push(
                     "/verify-transaction/hashes",
-                    extra: (widget.safeAccount, widget.transaction, widget.nonce)
+                    extra: (widget.safeAccount, widget.transaction)
                   );
                 },
                 child: const Text('Verify Hashes anyway'),
@@ -141,6 +139,27 @@ class _SafeTxSimulationScreenState extends State<SafeTxSimulationScreen> {
           children: [
             TrustMinimizedNote(),
             const SizedBox(height: 16),
+            if (widget.transaction.hasNonceMismatch) ...[
+              Card(
+                color: Colors.orange.shade600.withAlpha((255*0.1).floor()),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.warning, color: Colors.orange),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'This simulation runs against the account\'s current nonce rather than the nonce supplied in the transaction data. This allows the simulation to bypass the on-chain nonce verification check.',
+                          style: TextStyle(color: Colors.orange.shade900),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
             if (isDangerous) ...[
               _buildDangerousTransactionCard(context),
               const SizedBox(height: 16),
@@ -175,7 +194,7 @@ class _SafeTxSimulationScreenState extends State<SafeTxSimulationScreen> {
                   onPressed: () {
                     GoRouter.of(context).push(
                       "/verify-transaction/hashes",
-                      extra: (widget.safeAccount, widget.transaction, widget.nonce)
+                      extra: (widget.safeAccount, widget.transaction)
                     );
                   },
                   child: const Text('Verify Hashes'),

--- a/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
@@ -12,13 +12,11 @@ const bool _enablePhaseDelay = true;
 class SimulationLoadingScreen extends StatefulWidget {
   final SafeAccount safeAccount;
   final SafeTransaction transaction;
-  final BigInt nonce;
 
   const SimulationLoadingScreen({
     super.key,
     required this.safeAccount,
     required this.transaction,
-    required this.nonce,
   });
 
   @override
@@ -89,7 +87,7 @@ class _SimulationLoadingScreenState extends State<SimulationLoadingScreen> {
     if (mounted) {
       GoRouter.of(context).pushReplacement(
         '/verify-transaction/hashes',
-        extra: (widget.safeAccount, widget.transaction, widget.nonce),
+        extra: (widget.safeAccount, widget.transaction),
       );
     }
   }
@@ -98,7 +96,6 @@ class _SimulationLoadingScreenState extends State<SimulationLoadingScreen> {
     try {
       final (success, simulationResult, errorMessage) = await widget.transaction.simulate(
         widget.safeAccount,
-        nonce: widget.nonce,
         onPhaseChange: (phase) {
           _queuePhaseChange(phase);
         },
@@ -126,7 +123,7 @@ class _SimulationLoadingScreenState extends State<SimulationLoadingScreen> {
       if (mounted && !_isCancelled) {
         GoRouter.of(context).pushReplacement(
           "/verify-transaction/simulation-results",
-          extra: (widget.safeAccount, widget.transaction, widget.nonce, simulationResult),
+          extra: (widget.safeAccount, widget.transaction, simulationResult),
         );
       }
     } catch (e) {

--- a/lib/shared/models/hw_wallets/hw_content_generator.dart
+++ b/lib/shared/models/hw_wallets/hw_content_generator.dart
@@ -48,6 +48,5 @@ abstract class HWContentGenerator {
     Version appVersion,
     SafeAccount account,
     SafeTransaction transaction,
-    BigInt nonce
   );
 }

--- a/lib/shared/models/hw_wallets/ledger/ledger_nano_s_plus.dart
+++ b/lib/shared/models/hw_wallets/ledger/ledger_nano_s_plus.dart
@@ -114,7 +114,6 @@ class LedgerNanoSPlusContentGenerator extends HWContentGenerator {
     Version appVersion,
     SafeAccount account,
     SafeTransaction transaction,
-    BigInt nonce
   ) async {
     List<HWPageContent> result = [];
     result.add(HWPageContent(
@@ -147,7 +146,7 @@ class LedgerNanoSPlusContentGenerator extends HWContentGenerator {
       trail: "icon:chevron-right"
     ));
     //
-    var (_, messageHash) = await transaction.getMessageHash(account, nonce: nonce);
+    var (_, messageHash) = await transaction.getMessageHash(account);
     var messageHashLines = _getLinesForString(messageHash);
     messageHashLines = messageHashLines.map((e) => "text:normal:$e").toList();
     result.add(HWPageContent(

--- a/lib/shared/models/safe_transaction_model.dart
+++ b/lib/shared/models/safe_transaction_model.dart
@@ -25,6 +25,8 @@ class SafeTransaction {
   BigInt gasPrice;
   String gasToken;
   String refundReceiver;
+  BigInt? nonce;
+  BigInt? latestNonce;
 
   SafeTransaction({
     required this.to,
@@ -36,6 +38,8 @@ class SafeTransaction {
     required this.gasPrice,
     required this.gasToken,
     required this.refundReceiver,
+    this.nonce,
+    this.latestNonce,
   });
 
   factory SafeTransaction.fromJson(Map<String, dynamic> json, bool legacyJson) {
@@ -49,8 +53,26 @@ class SafeTransaction {
       gasPrice: json['gasPrice'] as BigInt,
       gasToken: json['gasToken'] as String,
       refundReceiver: json['refundReceiver'] as String,
+      nonce: json.containsKey('nonce') ? BigInt.from(json['nonce'] as int) : null,
     );
   }
+
+  /// Ensures nonce is set by fetching it from the account if not already set
+  /// Also fetches and stores the latest nonce from the account for simulation
+  Future<(bool, String)> ensureNonce(SafeAccount account) async {
+    final fetchedNonce = await account.getNonce();
+    if (fetchedNonce == null) {
+      return (false, 'Failed to fetch nonce');
+    }
+    latestNonce = fetchedNonce;
+    // If nonce is not set (CallData input), use the latest nonce
+    if (nonce == null) {
+      nonce = fetchedNonce;
+    }
+    return (true, '');
+  }
+
+  bool get hasNonceMismatch => nonce != null && latestNonce != null && nonce != latestNonce;
 
   Future<(List<String>, List<(String, String)>)> _getTransactionTracingSignatures(SafeAccount account, String transactionHash) async {
     List<String> signatures = [];
@@ -110,18 +132,18 @@ class SafeTransaction {
     return "0x6a761202${bytesToHex(callData, include0x: false)}";
   }
 
-  Future<(bool, String)> getMessageHash(SafeAccount account, {BigInt? nonce}) async {
+  Future<(bool, String)> getMessageHash(SafeAccount account, {bool useLatestNonce = false}) async {
     String safeTxTypeHash = SAFE_TX_TYPEHASH;
     var accountVersion = Version.parse(account.version);
     if (accountVersion < Version.parse("1.0.0")){
       safeTxTypeHash = SAFE_TX_TYPEHASH_OLD;
     }
-    if (nonce == null){
-      nonce = await account.getNonce();
-      if (nonce == null){
-        return (false, "Failed to fetch nonce");
-      }
+    final (success, error) = await ensureNonce(account);
+    if (!success) {
+      return (false, error);
     }
+    // Use latestNonce for simulation, nonce for hash verification
+    final nonceToUse = useLatestNonce ? latestNonce! : nonce!;
     Uint8List message = encodeAbi(
         [
           "bytes32",
@@ -147,7 +169,7 @@ class SafeTransaction {
           gasPrice,
           EthereumAddress.fromHex(gasToken),
           EthereumAddress.fromHex(refundReceiver),
-          nonce,
+          nonceToUse,
         ]
     );
     var messageHash = bytesToHex(keccak256(message), include0x: true);
@@ -163,16 +185,14 @@ class SafeTransaction {
     return txHash;
   }
 
-  Future<(bool, String, String, String)> calculateHashes(SafeAccount account, {BigInt? nonce}) async {
-    if (nonce == null){
-      nonce = await account.getNonce();
-      if (nonce == null){
-        return (false, "Failed to fetch nonce", '', '');
-      }
+  Future<(bool, String, String, String)> calculateHashes(SafeAccount account, {bool useLatestNonce = false}) async {
+    final (success, error) = await ensureNonce(account);
+    if (!success) {
+      return (false, error, '', '');
     }
     var domainHash = account.getDomainHash();
-    var (success, messageHash) = await getMessageHash(account, nonce: nonce);
-    if (!success){
+    var (msgSuccess, messageHash) = await getMessageHash(account, useLatestNonce: useLatestNonce);
+    if (!msgSuccess){
       return (false, "Failed to calculate message hash", '', '');
     }
     var txHash = getTransactionHash(domainHash, messageHash);
@@ -181,13 +201,15 @@ class SafeTransaction {
 
   Future<(bool, SimulationResult?, String)> simulate(
     SafeAccount account, {
-    BigInt? nonce,
     void Function(SimulationPhase)? onPhaseChange,
   }) async {
     try {
+      final (nonceSuccess, nonceError) = await ensureNonce(account);
+      if (!nonceSuccess) return (false, null, nonceError);
       // Fetching prestate
       onPhaseChange?.call(SimulationPhase.fetchingPrestate);
-      var (hashesSuccess, domainHash, messageHash, txHash) = await calculateHashes(account, nonce: nonce);
+      // Use latestNonce for simulation to bypass on-chain nonce verification
+      var (hashesSuccess, domainHash, messageHash, txHash) = await calculateHashes(account, useLatestNonce: true);
       if (!hashesSuccess) return (false, null, domainHash);
       var (signatures, storageLocationsOverrides) = await _getTransactionTracingSignatures(account, txHash);
       var evmTracer = EVMTracer(provider: account.network.provider);


### PR DESCRIPTION
  - Refactor nonce to be a field on SafeTransaction instead of parameter
  - Add latestNonce field to SafeTransaction model
  - Use latestNonce for simulations to bypass on-chain nonce checks
  - Display warning when simulation nonce differs from transaction nonce
  - Maintain transaction-supplied nonce for hash verification (latest hint is still displayed on NonceControl widget)