### PR TITLE
feat: improve card UX with minimal design

### DIFF
--- a/lib/features/account_management/account_listing_screen.dart
+++ b/lib/features/account_management/account_listing_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:safe_opensig/core/storage/accounts_box.dart';
-import 'package:safe_opensig/core/storage/misc_box.dart';
 import 'package:safe_opensig/core/theme/theme_config.dart';
 import 'package:safe_opensig/shared/constants/event_bus.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
@@ -18,13 +17,12 @@ class AccountListingScreen extends StatefulWidget {
 
 class _AccountListingScreenState extends State<AccountListingScreen> {
   late List<SafeAccount> _accounts;
-  late String? _selectedAccountId;
   late StreamSubscription _accountChangesSubscription;
 
   @override
   void initState() {
     _loadAccounts();
-    _accountChangesSubscription = eventBus.on<OnAccountStorageChange>().listen((event){
+    _accountChangesSubscription = eventBus.on<OnAccountStorageChange>().listen((event) {
       if (!mounted) return;
       _loadAccounts();
     });
@@ -40,179 +38,178 @@ class _AccountListingScreenState extends State<AccountListingScreen> {
   void _loadAccounts() {
     setState(() {
       _accounts = AccountsBox.getAccounts();
-      _selectedAccountId = MiscBox.getSelectedAccountId();
-    });
-  }
-
-  void _selectAccount(String accountId) {
-    MiscBox.setSelectedAccountId(accountId);
-    setState(() {
-      _selectedAccountId = accountId;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final accounts = _accounts;
-    final selectedAccountId = _selectedAccountId;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Safe Accounts'),
         actions: [
-          accounts.isNotEmpty ? IconButton(
-            icon: const Icon(Icons.add),
-            onPressed: () {
-              GoRouter.of(context).go('/accounts/add-account');
-            },
-          ) : const SizedBox.shrink(),
+          if (accounts.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: () {
+                GoRouter.of(context).go('/accounts/add-account');
+              },
+            ),
         ],
       ),
-      body: accounts.isEmpty ? _EmptyStateWidget() : ListView.builder(
-        padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
-        itemCount: accounts.length,
-        itemBuilder: (context, index) {
-          final account = accounts[index];
-          return _AccountCard(
-            account: account,
-            isActive: account.id == selectedAccountId,
-            onTap: () => _selectAccount(account.id),
-            onDelete: () {
-              AccountsBox.removeAccount(account.id);
-              if (selectedAccountId == account.id) {
-                MiscBox.setSelectedAccountId(null);
-              }
-              _loadAccounts();
-            },
-          );
-        },
-      ),
-      floatingActionButton: accounts.isNotEmpty ? FloatingActionButton.extended(
-        onPressed: () {
-          GoRouter.of(context).push("/verify-transaction", extra: AccountsBox.getAccount(selectedAccountId!)!);
-        },
-        label: const Text('Verify Safe Transaction'),
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        foregroundColor: Theme.of(context).colorScheme.onPrimary,
-      ) : null,
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      body: accounts.isEmpty
+          ? _EmptyStateWidget()
+          : Column(
+              children: [
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+                    itemCount: accounts.length,
+                    itemBuilder: (context, index) {
+                      final account = accounts[index];
+                      return _AccountCard(
+                        account: account,
+                        onTap: () {
+                          GoRouter.of(context).push("/verify-transaction", extra: account);
+                        },
+                        onEdit: () {
+                          GoRouter.of(context).go('/accounts/edit-account', extra: account);
+                        },
+                        onDelete: () {
+                          AccountsBox.removeAccount(account.id);
+                          _loadAccounts();
+                        },
+                      );
+                    },
+                  ),
+                ),
+                // Hint text
+                Padding(
+                  padding: const EdgeInsets.only(bottom: ThemeConfig.spacingMedium),
+                  child: Text(
+                    'Swipe or hold cards for options',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).textTheme.bodySmall?.color?.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
     );
   }
 }
 
 class _AccountCard extends StatelessWidget {
   final SafeAccount account;
-  final bool isActive;
   final VoidCallback onTap;
+  final VoidCallback onEdit;
   final VoidCallback onDelete;
 
   const _AccountCard({
     required this.account,
-    required this.isActive,
     required this.onTap,
+    required this.onEdit,
     required this.onDelete,
   });
 
   @override
   Widget build(BuildContext context) {
-    var borderColor = isActive ? Theme.of(context).colorScheme.primary : Colors.white.withValues(alpha: 0.5);
-    return AnimatedContainer(
-      duration: Duration(milliseconds: 100),
-      margin: const EdgeInsets.only(bottom: ThemeConfig.spacingMedium),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: ThemeConfig.borderRadiusLarge,
-        boxShadow: ThemeConfig.shadowMedium,
-        border: Border(
-          left: BorderSide(
-            color: borderColor,
-            width: isActive ? 4.0 : 1,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: ThemeConfig.spacingMedium),
+      child: Dismissible(
+        key: ValueKey(account.id),
+        confirmDismiss: (direction) async {
+          if (direction == DismissDirection.startToEnd) {
+            // Swipe RIGHT → Edit
+            onEdit();
+            return false; // Don't actually dismiss, just trigger edit
+          } else if (direction == DismissDirection.endToStart) {
+            // Swipe LEFT → Delete (with confirmation)
+            return await _showDeleteConfirmation(context);
+          }
+          return false;
+        },
+        onDismissed: (direction) {
+          if (direction == DismissDirection.endToStart) {
+            onDelete();
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Account deleted')),
+            );
+          }
+        },
+        background: Container(
+          // Swipe RIGHT background (Edit)
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(left: 20),
+          decoration: BoxDecoration(
+            color: ThemeConfig.primaryVariant,
+            borderRadius: BorderRadius.circular(12),
           ),
-          right: BorderSide(color: borderColor, width: 1),
-          top: BorderSide(color: borderColor, width: 1),
-          bottom: BorderSide(color: borderColor, width: 1)
+          child: const Icon(Icons.edit, color: Colors.white),
         ),
-      ),
-      child: Material(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: ThemeConfig.borderRadiusLarge,
-        elevation: isActive ? 10 : 3,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: ThemeConfig.borderRadiusLarge,
-          child: Padding(
-            padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
-            child: Row(
-              children: [
-                NetworkLogo(network: account.network),
-                const SizedBox(width: ThemeConfig.spacingMedium),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        account.name,
-                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 18,
+        secondaryBackground: Container(
+          // Swipe LEFT background (Delete)
+          alignment: Alignment.centerRight,
+          padding: const EdgeInsets.only(right: 20),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.error,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Icon(Icons.delete, color: Colors.white),
+        ),
+        child: Card(
+          margin: EdgeInsets.zero,
+          elevation: 1,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(
+              color: Theme.of(context).dividerColor,
+              width: 1,
+            ),
+          ),
+          child: InkWell(
+            onTap: onTap,
+            onLongPress: () => _showContextMenu(context),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Row(
+                children: [
+                  // Network logo
+                  NetworkLogo(network: account.network),
+                  const SizedBox(width: 14),
+
+                  // Account info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Account name
+                        Text(
+                          account.name,
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: ThemeConfig.spacingXSmall),
-                      Text(
-                        _trimAddress(account.address),
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                    ],
-                  ),
-                ),
-                PopupMenuButton<String>(
-                  icon: Icon(
-                    Icons.more_vert,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: ThemeConfig.borderRadiusLarge,
-                  ),
-                  onSelected: (String result) {
-                    if (result == 'edit') {
-                      _editAccount(context, account);
-                    } else if (result == 'delete') {
-                      _deleteAccount(context, account);
-                    }
-                  },
-                  menuPadding: EdgeInsets.zero,
-                  itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                    PopupMenuItem<String>(
-                      value: 'edit',
-                      child: Row(
-                        children: [
-                          Icon(
-                            Icons.edit,
-                            size: ThemeConfig.iconSizeMedium,
-                            color: Theme.of(context).colorScheme.onSurface,
-                          ),
-                          const SizedBox(width: ThemeConfig.spacingSmall),
-                          const Text('Edit'),
-                        ],
-                      ),
+                        const SizedBox(height: 4),
+                        // Address
+                        Text(
+                          _trimAddress(account.address),
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ],
                     ),
-                    PopupMenuItem<String>(
-                      value: 'delete',
-                      child: Row(
-                        children: [
-                          Icon(
-                            Icons.delete,
-                            size: ThemeConfig.iconSizeMedium,
-                            color: Theme.of(context).colorScheme.error,
-                          ),
-                          const SizedBox(width: ThemeConfig.spacingSmall),
-                          const Text('Delete'),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
+                  ),
+
+                  // Arrow indicator
+                  Icon(
+                    Icons.arrow_forward_ios,
+                    size: 16,
+                    color: Theme.of(context).primaryColor,
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -220,45 +217,74 @@ class _AccountCard extends StatelessWidget {
     );
   }
 
-  void _editAccount(BuildContext context, SafeAccount account) {
-    GoRouter.of(context).go('/accounts/edit-account', extra: account);
+  void _showContextMenu(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: Icon(Icons.edit, color: ThemeConfig.primaryVariant),
+                title: const Text('Edit'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onEdit();
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.delete, color: Theme.of(context).colorScheme.error),
+                title: const Text('Delete'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  final confirmed = await _showDeleteConfirmation(context);
+                  if (confirmed) {
+                    onDelete();
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Account deleted')),
+                      );
+                    }
+                  }
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
-  void _deleteAccount(BuildContext context, SafeAccount account) {
-    showDialog(
+  Future<bool> _showDeleteConfirmation(BuildContext context) async {
+    return await showDialog<bool>(
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
           title: const Text('Delete Account'),
-          content: Text('Are you sure you want to delete the account "${account.name}"?'),
+          content: Text('Are you sure you want to delete "${account.name}"?'),
           actions: [
             TextButton(
-              onPressed: () {
-                Navigator.of(dialogContext).pop();
-              },
+              onPressed: () => Navigator.of(dialogContext).pop(false),
               child: const Text('Cancel'),
             ),
             TextButton(
-              onPressed: () {
-                onDelete();
-                Navigator.of(dialogContext).pop();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Account deleted successfully!')),
-                );
-              },
+              onPressed: () => Navigator.of(dialogContext).pop(true),
               child: const Text('Delete'),
             ),
           ],
         );
       },
-    );
+    ) ?? false;
   }
 
   String _trimAddress(String address) {
     if (address.length <= 10) return address;
     return '${address.substring(0, 6)}...${address.substring(address.length - 4)}';
   }
-
 }
 
 class _EmptyStateWidget extends StatelessWidget {

--- a/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
+++ b/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
@@ -182,11 +182,14 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
                         ),
                       ),
                       const Spacer(),
-                      ElevatedButton(
-                        onPressed: safeTransaction != null ? _onSubmit : null,
-                        child: const Text('Submit'),
-                      ),
-                      const SizedBox(height: 16),
+                      // Only show Submit button for Manual Input tab
+                      if (currentIndex == 1) ...[
+                        ElevatedButton(
+                          onPressed: safeTransaction != null ? _onSubmit : null,
+                          child: const Text('Submit'),
+                        ),
+                        const SizedBox(height: 16),
+                      ],
                     ],
                   ),
                 ),
@@ -303,6 +306,7 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
             safeAccount: widget.safeAccount,
             onValidInput: (safeTx){
               setState(() => safeTransaction = safeTx);
+              _onSubmit();
             },
           ),
           const SizedBox(height: 10),

--- a/lib/features/verify_safe_transaction/widgets/safe_api_transaction_card.dart
+++ b/lib/features/verify_safe_transaction/widgets/safe_api_transaction_card.dart
@@ -33,6 +33,18 @@ class SafeAPITransactionCard extends StatelessWidget {
 
   bool get _isDelegateCall => transaction.operation == 1;
 
+  String _formatDate(DateTime date) {
+    final local = date.toLocal();
+    final month = local.month;
+    final day = local.day;
+    final year = local.year;
+    final hour = local.hour > 12 ? local.hour - 12 : (local.hour == 0 ? 12 : local.hour);
+    final minute = local.minute.toString().padLeft(2, '0');
+    final second = local.second.toString().padLeft(2, '0');
+    final period = local.hour >= 12 ? 'PM' : 'AM';
+    return '$month/$day/$year, $hour:$minute:$second $period';
+  }
+
   @override
   Widget build(BuildContext context) {
     final isReady = transaction.isFullyConfirmed;
@@ -113,28 +125,39 @@ class SafeAPITransactionCard extends StatelessWidget {
                 ],
               ),
 
-              const SizedBox(height: 8),
+              const SizedBox(height: 10),
 
-              // Row 2: To address + Arrow
+              // To address (subtle)
+              Text(
+                'To: ${Utilities.truncateIfAddress(transaction.to)}',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Theme.of(context).textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
+                ),
+              ),
+
+              const SizedBox(height: 12),
+
+              // Created date (prominent) + Arrow
               Row(
                 children: [
-                  Text(
-                    'To: ',
-                    style: TextStyle(
-                      color: Theme.of(context).textTheme.bodyMedium?.color?.withValues(alpha: 0.7),
-                      fontSize: 14,
+                  if (transaction.submissionDate != null) ...[
+                    Icon(
+                      Icons.access_time,
+                      size: 16,
+                      color: Theme.of(context).primaryColor,
                     ),
-                  ),
-                  Expanded(
-                    child: Text(
-                      Utilities.truncateIfAddress(transaction.to),
+                    const SizedBox(width: 6),
+                    Text(
+                      _formatDate(transaction.submissionDate!),
                       style: TextStyle(
-                        fontFamily: 'monospace',
-                        fontSize: 14,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
                         color: Theme.of(context).textTheme.bodyMedium?.color,
                       ),
                     ),
-                  ),
+                  ],
+                  const Spacer(),
                   Icon(
                     Icons.arrow_forward_ios,
                     size: 16,
@@ -183,7 +206,7 @@ class SafeAPITransactionCard extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.hourglass_top, size: 14, color: Colors.orange.shade700),
+            Icon(Icons.people_outline, size: 14, color: Colors.orange.shade700),
             const SizedBox(width: 4),
             Text(
               '${transaction.confirmations}/${transaction.confirmationsRequired}',

--- a/lib/features/verify_safe_transaction/widgets/safe_api_transaction_card.dart
+++ b/lib/features/verify_safe_transaction/widgets/safe_api_transaction_card.dart
@@ -1,62 +1,147 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:safe_opensig/shared/models/safe_api_transaction_model.dart';
 import 'package:safe_opensig/shared/utils/utilities.dart';
 
-class SafeAPITransactionCard extends StatefulWidget {
+class SafeAPITransactionCard extends StatelessWidget {
   final SafeAPITransaction transaction;
-  final bool isSelected;
   final String nativeCurrencySymbol;
-  final VoidCallback onTap;
+  final VoidCallback onSelect;
 
   const SafeAPITransactionCard({
     super.key,
     required this.transaction,
-    required this.isSelected,
     required this.nativeCurrencySymbol,
-    required this.onTap,
+    required this.onSelect,
   });
 
-  @override
-  State<SafeAPITransactionCard> createState() =>
-      _SafeAPITransactionCardState();
-}
+  /// Determine the primary action description based on transaction data
+  String get _primaryAction {
+    final hasData = transaction.data.isNotEmpty && transaction.data != '0x';
+    final hasValue = transaction.value > BigInt.zero;
+    final formattedValue = Utilities.formatCryptoAmount(transaction.value, 18);
 
-class _SafeAPITransactionCardState extends State<SafeAPITransactionCard> {
-  bool _isExpanded = false;
+    if (hasValue && hasData) {
+      return 'Send $formattedValue $nativeCurrencySymbol + Call';
+    } else if (hasValue) {
+      return 'Send $formattedValue $nativeCurrencySymbol';
+    } else if (hasData) {
+      return 'Contract call';
+    } else {
+      return 'Empty transaction';
+    }
+  }
+
+  bool get _isDelegateCall => transaction.operation == 1;
 
   @override
   Widget build(BuildContext context) {
+    final isReady = transaction.isFullyConfirmed;
+
     return Card(
-      elevation: widget.isSelected ? 4 : 1,
+      elevation: 1,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
         side: BorderSide(
-          color: widget.isSelected
-            ? Theme.of(context).primaryColor
-            : Colors.grey.shade300,
-          width: widget.isSelected ? 2 : 1,
+          color: _isDelegateCall
+              ? Colors.orange.shade400
+              : Theme.of(context).dividerColor,
+          width: _isDelegateCall ? 2 : 1,
         ),
       ),
       child: InkWell(
-        onTap: widget.onTap,
+        onTap: onSelect,
         borderRadius: BorderRadius.circular(12),
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildHeader(),
-              const SizedBox(height: 12),
-              _buildBasicInfo(),
-              const SizedBox(height: 12),
-              _buildConfirmationsInfo(),
-              if (_isExpanded) ...[
-                const Divider(height: 24),
-                _buildExpandedDetails(),
+              // Warning banner for DELEGATECALL
+              if (_isDelegateCall) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.orange.shade100,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.warning_amber, size: 14, color: Colors.orange.shade800),
+                      const SizedBox(width: 4),
+                      Text(
+                        'DELEGATECALL',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.orange.shade800,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 10),
               ],
+
+              // Row 1: Nonce + Primary action + Confirmations
+              Row(
+                children: [
+                  // Nonce
+                  Text(
+                    '#${transaction.nonce}',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '·',
+                    style: TextStyle(color: Colors.grey.shade500),
+                  ),
+                  const SizedBox(width: 8),
+                  // Primary action
+                  Expanded(
+                    child: Text(
+                      _primaryAction,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Confirmation status
+                  _buildConfirmationBadge(context, isReady),
+                ],
+              ),
+
               const SizedBox(height: 8),
-              _buildExpandButton(),
+
+              // Row 2: To address + Arrow
+              Row(
+                children: [
+                  Text(
+                    'To: ',
+                    style: TextStyle(
+                      color: Theme.of(context).textTheme.bodyMedium?.color?.withValues(alpha: 0.7),
+                      fontSize: 14,
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      Utilities.truncateIfAddress(transaction.to),
+                      style: TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 14,
+                        color: Theme.of(context).textTheme.bodyMedium?.color,
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    Icons.arrow_forward_ios,
+                    size: 16,
+                    color: Theme.of(context).primaryColor,
+                  ),
+                ],
+              ),
             ],
           ),
         ),
@@ -64,280 +149,53 @@ class _SafeAPITransactionCardState extends State<SafeAPITransactionCard> {
     );
   }
 
-  Widget _buildHeader() {
-    return Row(
-      children: [
-        // Selection indicator
-        Icon(
-          widget.isSelected
-              ? Icons.radio_button_checked
-              : Icons.radio_button_unchecked,
-          color: widget.isSelected
-              ? Theme.of(context).primaryColor
-              : Colors.grey.shade400,
-          size: 20,
+  Widget _buildConfirmationBadge(BuildContext context, bool isReady) {
+    if (isReady) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.green.shade50,
+          borderRadius: BorderRadius.circular(12),
         ),
-        const SizedBox(width: 12),
-
-        // Nonce
-        Text(
-          'Nonce: ${widget.transaction.nonce}',
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        const Spacer(),
-
-        // Operation type badge
-        _buildOperationBadge(),
-      ],
-    );
-  }
-
-  Widget _buildOperationBadge() {
-    final isCall = widget.transaction.operation == 0;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: isCall ? Colors.blue.shade50 : Colors.orange.shade50,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: isCall ? Colors.blue.shade200 : Colors.orange.shade200,
-        ),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            isCall ? Icons.call_made : Icons.swap_calls,
-            size: 12,
-            color: isCall ? Colors.blue.shade700 : Colors.orange.shade700,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            widget.transaction.operationType,
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: isCall ? Colors.blue.shade700 : Colors.orange.shade700,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildBasicInfo() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // To address
-        Row(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.account_balance_wallet, size: 16, color: Colors.grey.shade600),
-            const SizedBox(width: 8),
+            Icon(Icons.check_circle, size: 14, color: Colors.green.shade700),
+            const SizedBox(width: 4),
             Text(
-              'To:',
+              'Ready',
               style: TextStyle(
-                color: Colors.grey.shade600,
-                fontSize: 13,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                Utilities.truncateIfAddress(widget.transaction.to),
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                ),
-              ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.copy, size: 16),
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(),
-              onPressed: () => _copyToClipboard(widget.transaction.to),
-            ),
-          ],
-        ),
-        const SizedBox(height: 8),
-
-        // Value
-        Row(
-          children: [
-            Icon(Icons.monetization_on, size: 16, color: Colors.grey.shade600),
-            const SizedBox(width: 8),
-            Text(
-              'Value:',
-              style: TextStyle(
-                color: Colors.grey.shade600,
-                fontSize: 13,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Text(
-              Utilities.formatCryptoAmount(widget.transaction.value, 18),
-              style: const TextStyle(
+                fontSize: 12,
                 fontWeight: FontWeight.w600,
-                fontSize: 13,
+                color: Colors.green.shade700,
               ),
             ),
           ],
         ),
-
-        // Safe tx hash
-        const SizedBox(height: 8),
-        Row(
-          children: [
-            Icon(Icons.tag, size: 16, color: Colors.grey.shade600),
-            const SizedBox(width: 8),
-            Text(
-              'Hash:',
-              style: TextStyle(
-                color: Colors.grey.shade600,
-                fontSize: 13,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                Utilities.truncate(widget.transaction.safeTxHash),
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                ),
-              ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.copy, size: 16),
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(),
-              onPressed: () => _copyToClipboard(widget.transaction.safeTxHash),
-            ),
-          ],
+      );
+    } else {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.orange.shade50,
+          borderRadius: BorderRadius.circular(12),
         ),
-      ],
-    );
-  }
-
-  Widget _buildConfirmationsInfo() {
-    final progress = widget.transaction.confirmationProgress;
-    final isFullyConfirmed = widget.transaction.isFullyConfirmed;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              isFullyConfirmed ? Icons.check_circle : Icons.pending,
-              size: 16,
-              color: isFullyConfirmed ? Colors.green : Colors.orange,
-            ),
-            const SizedBox(width: 8),
+            Icon(Icons.hourglass_top, size: 14, color: Colors.orange.shade700),
+            const SizedBox(width: 4),
             Text(
-              'Confirmations: ${widget.transaction.confirmations}/${widget.transaction.confirmationsRequired}',
+              '${transaction.confirmations}/${transaction.confirmationsRequired}',
               style: TextStyle(
-                fontSize: 13,
-                color: isFullyConfirmed ? Colors.green.shade700 : Colors.orange.shade700,
+                fontSize: 12,
                 fontWeight: FontWeight.w600,
+                color: Colors.orange.shade700,
               ),
             ),
           ],
         ),
-        const SizedBox(height: 8),
-        LinearProgressIndicator(
-          value: progress,
-          backgroundColor: Colors.grey.shade200,
-          valueColor: AlwaysStoppedAnimation<Color>(
-            isFullyConfirmed ? Colors.green : Colors.orange,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildExpandedDetails() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Gas Parameters',
-          style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 12),
-        _buildDetailRow('Safe Tx Gas', widget.transaction.safeTxGas.toString()),
-        const SizedBox(height: 6),
-        _buildDetailRow('Base Gas', widget.transaction.baseGas.toString()),
-        const SizedBox(height: 6),
-        _buildDetailRow('Gas Price', '${widget.transaction.gasPrice} wei'),
-        const SizedBox(height: 6),
-        _buildDetailRow('Gas Token', Utilities.truncateIfAddress(widget.transaction.gasToken)),
-        const SizedBox(height: 6),
-        _buildDetailRow('Refund Receiver', Utilities.truncateIfAddress(widget.transaction.refundReceiver)),
-      ],
-    );
-  }
-
-  Widget _buildDetailRow(String label, String value) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: 120,
-          child: Text(
-            label,
-            style: TextStyle(
-              color: Colors.grey.shade600,
-              fontSize: 12,
-            ),
-          ),
-        ),
-        Expanded(
-          child: Text(
-            value,
-            style: const TextStyle(
-              fontFamily: 'monospace',
-              fontSize: 12,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildExpandButton() {
-    return Center(
-      child: TextButton.icon(
-        onPressed: () {
-          setState(() {
-            _isExpanded = !_isExpanded;
-          });
-        },
-        icon: Icon(
-          _isExpanded ? Icons.expand_less : Icons.expand_more,
-          size: 18,
-        ),
-        label: Text(
-          _isExpanded ? 'Show less' : 'Show gas parameters',
-          style: const TextStyle(fontSize: 12),
-        ),
-        style: TextButton.styleFrom(
-          padding: EdgeInsets.zero,
-          minimumSize: const Size(0, 32),
-        ),
-      ),
-    );
-  }
-
-  void _copyToClipboard(String text) {
-    Clipboard.setData(ClipboardData(text: text));
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Copied to clipboard'),
-        duration: Duration(seconds: 1),
-      ),
-    );
+      );
+    }
   }
 }

--- a/lib/features/verify_safe_transaction/widgets/safe_tx_api_input.dart
+++ b/lib/features/verify_safe_transaction/widgets/safe_tx_api_input.dart
@@ -25,7 +25,6 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
   LoadingState _state = LoadingState.idle;
   List<SafeAPITransaction>? _transactions;
   String? _errorMessage;
-  SafeAPITransaction? _selectedTransaction;
   final SafeTransactionService _service = SafeTransactionService();
 
   @override
@@ -38,7 +37,6 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
     setState(() {
       _state = LoadingState.loading;
       _errorMessage = null;
-      _selectedTransaction = null;
     });
 
     final (success, transactions, error) = await _service.getQueuedTransactions(
@@ -62,10 +60,7 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
     }
   }
 
-  void _onTransactionSelected(SafeAPITransaction transaction) async {
-    setState(() {
-      _selectedTransaction = transaction;
-    });
+  void _onTransactionSelected(SafeAPITransaction transaction) {
     final safeTx = transaction.toSafeTransaction();
     widget.onValidInput(safeTx);
   }
@@ -220,9 +215,8 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
                 padding: const EdgeInsets.only(bottom: 12),
                 child: SafeAPITransactionCard(
                   transaction: transaction,
-                  isSelected: _selectedTransaction == transaction,
                   nativeCurrencySymbol: widget.safeAccount.network.nativeCurrencySymbol,
-                  onTap: () => _onTransactionSelected(transaction),
+                  onSelect: () => _onTransactionSelected(transaction),
                 ),
               ),
           ],

--- a/lib/features/verify_safe_transaction/widgets/safe_tx_api_input.dart
+++ b/lib/features/verify_safe_transaction/widgets/safe_tx_api_input.dart
@@ -184,7 +184,21 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
     );
   }
 
+  /// Groups transactions by nonce for conflict detection
+  Map<BigInt, List<SafeAPITransaction>> _groupByNonce(List<SafeAPITransaction> transactions) {
+    final Map<BigInt, List<SafeAPITransaction>> grouped = {};
+    for (final tx in transactions) {
+      final nonce = tx.nonce ?? BigInt.zero;
+      grouped.putIfAbsent(nonce, () => []);
+      grouped[nonce]!.add(tx);
+    }
+    return grouped;
+  }
+
   Widget _buildSuccessState() {
+    final groupedByNonce = _groupByNonce(_transactions!);
+    final sortedNonces = groupedByNonce.keys.toList()..sort();
+
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -210,17 +224,85 @@ class _SafeTxAPIInputState extends State<SafeTxAPIInput> {
               ],
             ),
             const SizedBox(height: 8),
-            for (var transaction in _transactions!)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: SafeAPITransactionCard(
-                  transaction: transaction,
-                  nativeCurrencySymbol: widget.safeAccount.network.nativeCurrencySymbol,
-                  onSelect: () => _onTransactionSelected(transaction),
-                ),
-              ),
+            for (final nonce in sortedNonces)
+              _buildNonceGroup(nonce, groupedByNonce[nonce]!),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildNonceGroup(BigInt nonce, List<SafeAPITransaction> transactions) {
+    final isConflicting = transactions.length > 1;
+
+    if (!isConflicting) {
+      // Single transaction - no grouping needed
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: SafeAPITransactionCard(
+          transaction: transactions.first,
+          nativeCurrencySymbol: widget.safeAccount.network.nativeCurrencySymbol,
+          onSelect: () => _onTransactionSelected(transactions.first),
+        ),
+      );
+    }
+
+    // Multiple transactions with same nonce - show conflict group
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.orange.shade400, width: 1.5),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Conflict warning banner
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: Colors.orange.shade400.withValues(alpha: 0.15),
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(10),
+                topRight: Radius.circular(10),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.warning_amber, size: 18, color: Colors.orange.shade600),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Conflicting transactions. Select the one you want executed',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.orange.shade600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Transaction cards
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              children: [
+                for (int i = 0; i < transactions.length; i++)
+                  Padding(
+                    padding: EdgeInsets.only(bottom: i < transactions.length - 1 ? 8 : 0),
+                    child: SafeAPITransactionCard(
+                      transaction: transactions[i],
+                      nativeCurrencySymbol: widget.safeAccount.network.nativeCurrencySymbol,
+                      onSelect: () => _onTransactionSelected(transactions[i]),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/shared/models/safe_api_transaction_model.dart
+++ b/lib/shared/models/safe_api_transaction_model.dart
@@ -7,6 +7,7 @@ class SafeAPITransaction extends SafeTransaction {
   final String safeTxHash;
   final int confirmations;
   final int confirmationsRequired;
+  final DateTime? submissionDate;
 
   SafeAPITransaction({
     required this.safeTxHash,
@@ -22,6 +23,7 @@ class SafeAPITransaction extends SafeTransaction {
     required super.nonce,
     required this.confirmations,
     required this.confirmationsRequired,
+    this.submissionDate,
   });
 
   factory SafeAPITransaction.fromJson(Map<String, dynamic> json) {
@@ -41,6 +43,9 @@ class SafeAPITransaction extends SafeTransaction {
         nonce: _parseBigInt(json['nonce']),
         confirmations: (json['confirmations'] as List?)?.length ?? 0,
         confirmationsRequired: _parseInt(json['confirmationsRequired']),
+        submissionDate: json['submissionDate'] != null
+            ? DateTime.tryParse(json['submissionDate'] as String)
+            : null,
       );
     } catch (e) {
       throw FormatException('Failed to parse SafeApiTransaction: $e');


### PR DESCRIPTION
## Summary
Redesign transaction and account cards for better UX. Cards now tap-to-proceed with swipe gestures for secondary actions. Fixes #23 and #22  

## Changes

### Transaction Card
- Simplified to show only what's needed to identify a transaction (nonce, action, confirmation status)
- Removed detailed info (hash, gas params, copy buttons) - these are shown on the verification screen where they matter
- Entire card tappable → proceeds directly

### Account Card
- Swipe right to edit, swipe left to delete
- Long-press menu as fallback for discoverability
- Removed selection state - tap proceeds directly

## Test plan
- [ ] Test card tap navigation
- [ ] Test swipe gestures on account cards
- [ ] Test long-press menu