### PR TITLE
feat: add support for network configuration overrides

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -9,6 +9,10 @@ import 'package:safe_opensig/features/onboarding/onboarding_screen.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/ledger_verification/safe_ledger_verify_screen.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/safe_transaction_form_screen.dart';
+import 'package:safe_opensig/features/settings/network_config_screen.dart';
+import 'package:safe_opensig/features/settings/network_config_override_screen.dart';
+import 'package:safe_opensig/features/settings/networks_listing_configuration_screen.dart';
+import 'package:safe_opensig/features/settings/settings_screen.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/simulation/simulation_loading_screen.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
@@ -43,6 +47,34 @@ final GoRouter router = GoRouter(
           },
         ),
       ]
+    ),
+    GoRoute(
+      path: '/settings',
+      builder: (context, state) => const SettingsScreen(),
+      routes: [
+        GoRoute(
+          path: 'node-settings',
+          builder: (context, state) => const NetworksListingConfigScreen(),
+          routes: [
+            GoRoute(
+              path: 'configure',
+              builder: (context, state) {
+                final int chainId = state.extra as int;
+                return NetworkConfigScreen(chainId: chainId);
+              },
+              routes: [
+                GoRoute(
+                  path: 'override',
+                  builder: (context, state) {
+                    final int chainId = state.extra as int;
+                    return NetworkConfigOverrideScreen(chainId: chainId);
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
     ),
     GoRoute(
       path: '/verify-transaction',

--- a/lib/core/storage/network_config_box.dart
+++ b/lib/core/storage/network_config_box.dart
@@ -1,0 +1,53 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:safe_opensig/shared/constants/event_bus.dart';
+import 'package:safe_opensig/shared/models/custom_network_config.dart';
+
+class NetworkConfigBox {
+  static late Box _box;
+  static const String boxName = 'box:network-configs';
+
+  static Future<void> init() async {
+    _box = await Hive.openBox(boxName);
+  }
+
+  static Future<void> setConfig(CustomNetworkConfig config) async {
+    await _box.put(config.chainId.toString(), config.toJson());
+    eventBus.fire(const OnNodeConfigChange());
+  }
+
+  static Future<void> removeConfig(int chainId) async {
+    await _box.delete(chainId.toString());
+    eventBus.fire(const OnNodeConfigChange());
+  }
+
+  static CustomNetworkConfig? getConfig(int chainId) {
+    final json = _box.get(chainId.toString());
+    if (json == null) return null;
+    return CustomNetworkConfig.fromJson(
+      (json as Map<dynamic, dynamic>).cast<String, dynamic>(),
+    );
+  }
+
+  static Map<int, CustomNetworkConfig> getAllConfigs() {
+    final configs = <int, CustomNetworkConfig>{};
+    for (final key in _box.keys) {
+      final json = _box.get(key);
+      if (json != null) {
+        final config = CustomNetworkConfig.fromJson(
+          (json as Map<dynamic, dynamic>).cast<String, dynamic>(),
+        );
+        configs[config.chainId] = config;
+      }
+    }
+    return configs;
+  }
+
+  static bool hasCustomConfig(int chainId) {
+    return _box.containsKey(chainId.toString());
+  }
+
+  static Future<void> clearAll() async {
+    await _box.clear();
+    eventBus.fire(const OnNodeConfigChange());
+  }
+}

--- a/lib/features/account_management/account_listing_screen.dart
+++ b/lib/features/account_management/account_listing_screen.dart
@@ -49,6 +49,12 @@ class _AccountListingScreenState extends State<AccountListingScreen> {
       appBar: AppBar(
         title: const Text('Safe Accounts'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.settings_outlined),
+            onPressed: () {
+              GoRouter.of(context).go('/settings');
+            },
+          ),
           if (accounts.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.add),

--- a/lib/features/settings/network_config_override_screen.dart
+++ b/lib/features/settings/network_config_override_screen.dart
@@ -28,6 +28,7 @@ class _NetworkConfigOverrideScreenState
   late TextEditingController _primaryUrlController;
   late TextEditingController _explorerUrlController;
   final List<TextEditingController> _secondaryUrlControllers = [];
+  late bool _hasCustomConfig;
 
   // Chain ID verification state: url -> null (not checked), true (ok), false (failed)
   final Map<String, bool?> _chainIdResults = {};
@@ -37,6 +38,7 @@ class _NetworkConfigOverrideScreenState
   void initState() {
     super.initState();
     _network = getDefaultNetwork(widget.chainId);
+    _hasCustomConfig = NetworkConfigBox.hasCustomConfig(widget.chainId);
 
     final existing = NetworkConfigBox.getConfig(widget.chainId);
 
@@ -268,6 +270,54 @@ class _NetworkConfigOverrideScreenState
             discardedCount > 0
                 ? 'Configuration saved ($discardedCount node(s) discarded due to chain ID mismatch)'
                 : 'Configuration saved',
+          ),
+        ),
+      );
+      context.pop();
+    }
+  }
+
+  Future<void> _revertToRecommended() async {
+    final theme = Theme.of(context);
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            icon: const Icon(
+              Icons.restore,
+              color: Colors.blue,
+              size: 40,
+            ),
+            title: const Text('Revert to Recommended?'),
+            content: Text(
+              'This will remove your custom configuration for '
+              '${_network.name} and restore the recommended defaults.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Revert'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (!confirmed || !mounted) return;
+
+    await NetworkConfigBox.removeConfig(widget.chainId);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${_network.name} reverted to recommended configuration',
           ),
         ),
       );
@@ -685,11 +735,19 @@ class _NetworkConfigOverrideScreenState
                     : const Text('Save Network Configuration'),
               ),
             ),
+            if (_hasCustomConfig) ...[
+              const SizedBox(height: 4),
+              TextButton.icon(
+                onPressed: _isChecking ? null : _revertToRecommended,
+                icon: const Icon(Icons.restore, size: 16),
+                label: const Text('Revert to Recommended'),
+              ),
+            ],
             const SizedBox(height: 4),
             TextButton(
               onPressed: () => context.pop(),
               child: Text(
-                'Cancel Changes',
+                'Cancel',
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
                 ),

--- a/lib/features/settings/network_config_override_screen.dart
+++ b/lib/features/settings/network_config_override_screen.dart
@@ -35,6 +35,10 @@ class _NetworkConfigOverrideScreenState
   final Map<String, bool?> _chainIdResults = {};
   bool _chainIdChecked = false;
 
+  // eth_getProof support state for secondary nodes: url -> true (ok), false (failed)
+  final Map<String, bool?> _ethGetProofResults = {};
+  bool _ethGetProofChecked = false;
+
   @override
   void initState() {
     super.initState();
@@ -254,6 +258,50 @@ class _NetworkConfigOverrideScreenState
     if (duplicatesRemoved > 0 && mounted) {
       final proceed = await _showDuplicateNodesWarningDialog(duplicatesRemoved);
       if (!proceed) return;
+    }
+
+    // Step 3: Verify eth_getProof support on all secondary nodes
+    setState(() {
+      _isChecking = true;
+      _ethGetProofResults.clear();
+      _ethGetProofChecked = false;
+    });
+
+    final proofFutures = <Future<void>>[];
+    for (final url in deduplicatedSecondary) {
+      proofFutures.add(
+        Utilities.checkEthGetProofSupport(url).then((ok) {
+          if (mounted) {
+            setState(() => _ethGetProofResults[url] = ok);
+          }
+        }),
+      );
+    }
+    await Future.wait(proofFutures);
+
+    if (mounted) {
+      setState(() {
+        _isChecking = false;
+        _ethGetProofChecked = true;
+      });
+    }
+    if (!mounted) return;
+
+    final proofFailedUrls = deduplicatedSecondary
+        .where((url) => _ethGetProofResults[url] == false)
+        .toList();
+
+    if (proofFailedUrls.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${proofFailedUrls.length} secondary node(s) do not support '
+            'eth_getProof, which is required for state verification. '
+            'Replace the failing node(s) before saving.',
+          ),
+        ),
+      );
+      return;
     }
 
     // Require at least 1 unique secondary node after deduplication
@@ -625,6 +673,12 @@ class _NetworkConfigOverrideScreenState
         _chainIdResults.clear();
       });
     }
+    if (_ethGetProofChecked) {
+      setState(() {
+        _ethGetProofChecked = false;
+        _ethGetProofResults.clear();
+      });
+    }
     if (_showDuplicateWarnTrailingIcon){
       setState(() {
         _showDuplicateWarnTrailingIcon = false;
@@ -632,9 +686,12 @@ class _NetworkConfigOverrideScreenState
     }
   }
 
-  Widget? _buildChainIdStatusIcon(bool? result, bool isSecondary) {
+  Widget? _buildChainIdStatusIcon(bool? result, bool isSecondary, {String? url}) {
     if (isSecondary && _showDuplicateWarnTrailingIcon){
       return const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 20);
+    }
+    if (isSecondary && url != null && _ethGetProofChecked && _ethGetProofResults[url] == false) {
+      return const Icon(Icons.cancel, color: Colors.red, size: 20);
     }
     if (result == null) return null;
     if (result) {
@@ -680,7 +737,7 @@ class _NetworkConfigOverrideScreenState
                             minWidth: 32,
                             minHeight: 0,
                           ),
-                          suffixIcon: _buildChainIdStatusIcon(chainResult, true),
+                          suffixIcon: _buildChainIdStatusIcon(chainResult, true, url: url),
                         ),
                         keyboardType: TextInputType.url,
                         validator: (value) =>
@@ -710,6 +767,17 @@ class _NetworkConfigOverrideScreenState
                       'Will be discarded — chain ID mismatch or unreachable',
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: Colors.amber.shade700,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+                if (_ethGetProofChecked && _ethGetProofResults[url] == false)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4, left: 4, bottom: 4),
+                    child: Text(
+                      'Does not support eth_getProof — required for state verification',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.error,
                         fontSize: 11,
                       ),
                     ),

--- a/lib/features/settings/network_config_override_screen.dart
+++ b/lib/features/settings/network_config_override_screen.dart
@@ -24,6 +24,7 @@ class _NetworkConfigOverrideScreenState
   final _formKey = GlobalKey<FormState>();
   late Network _network;
   bool _isChecking = false;
+  bool _showDuplicateWarnTrailingIcon = false;
 
   late TextEditingController _primaryUrlController;
   late TextEditingController _explorerUrlController;
@@ -49,10 +50,13 @@ class _NetworkConfigOverrideScreenState
       text: existing?.explorerUrl ?? '',
     );
 
-    if (existing != null) {
+    if (existing != null && existing.secondaryNodeUrls.isNotEmpty) {
       for (final url in existing.secondaryNodeUrls) {
         _secondaryUrlControllers.add(TextEditingController(text: url));
       }
+    } else {
+      // Always start with at least one secondary node field
+      _secondaryUrlControllers.add(TextEditingController());
     }
   }
 
@@ -252,6 +256,24 @@ class _NetworkConfigOverrideScreenState
       if (!proceed) return;
     }
 
+    // Require at least 1 unique secondary node after deduplication
+    if (deduplicatedSecondary.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'At least 1 secondary node is required for state verification. '
+              'Add a node that differs from the primary.',
+            ),
+          ),
+        );
+      }
+      setState(() {
+        _showDuplicateWarnTrailingIcon = true;
+      });
+      return;
+    }
+
     final config = CustomNetworkConfig(
       chainId: widget.chainId,
       primaryNodeUrl: primaryUrl,
@@ -400,7 +422,7 @@ class _NetworkConfigOverrideScreenState
                     const SizedBox(height: ThemeConfig.spacingLarge),
                     _buildSectionLabel(
                       theme,
-                      'Secondary nodes',
+                      'Secondary nodes (min. 1 required)',
                       infoText:
                           'Secondary nodes are used to independently verify, '
                           'through Merkle tree proofs, that the state fetched '
@@ -569,7 +591,7 @@ class _NetworkConfigOverrideScreenState
               minWidth: 32,
               minHeight: 0,
             ),
-            suffixIcon: _buildChainIdStatusIcon(chainResult),
+            suffixIcon: _buildChainIdStatusIcon(chainResult, false),
           ),
           keyboardType: TextInputType.url,
           validator: (value) => value?.validateHttpsUrl(),
@@ -603,9 +625,17 @@ class _NetworkConfigOverrideScreenState
         _chainIdResults.clear();
       });
     }
+    if (_showDuplicateWarnTrailingIcon){
+      setState(() {
+        _showDuplicateWarnTrailingIcon = false;
+      });
+    }
   }
 
-  Widget? _buildChainIdStatusIcon(bool? result) {
+  Widget? _buildChainIdStatusIcon(bool? result, bool isSecondary) {
+    if (isSecondary && _showDuplicateWarnTrailingIcon){
+      return const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 20);
+    }
     if (result == null) return null;
     if (result) {
       return const Icon(Icons.check_circle, color: Colors.green, size: 20);
@@ -650,7 +680,7 @@ class _NetworkConfigOverrideScreenState
                             minWidth: 32,
                             minHeight: 0,
                           ),
-                          suffixIcon: _buildChainIdStatusIcon(chainResult),
+                          suffixIcon: _buildChainIdStatusIcon(chainResult, true),
                         ),
                         keyboardType: TextInputType.url,
                         validator: (value) =>
@@ -661,10 +691,14 @@ class _NetworkConfigOverrideScreenState
                     IconButton(
                       icon: Icon(
                         Icons.delete_outline,
-                        color: theme.colorScheme.error,
+                        color: _secondaryUrlControllers.length > 1
+                            ? theme.colorScheme.error
+                            : theme.disabledColor,
                         size: 20,
                       ),
-                      onPressed: () => _removeSecondaryUrl(index),
+                      onPressed: _secondaryUrlControllers.length > 1
+                          ? () => _removeSecondaryUrl(index)
+                          : null,
                       visualDensity: VisualDensity.compact,
                     ),
                   ],

--- a/lib/features/settings/network_config_override_screen.dart
+++ b/lib/features/settings/network_config_override_screen.dart
@@ -1,0 +1,703 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
+import 'package:safe_opensig/core/theme/theme_config.dart';
+import 'package:safe_opensig/shared/constants/network_constants.dart';
+import 'package:safe_opensig/shared/models/custom_network_config.dart';
+import 'package:safe_opensig/shared/models/network_model.dart';
+import 'package:safe_opensig/shared/utils/extensions/string_extensions.dart';
+import 'package:safe_opensig/shared/utils/utilities.dart';
+import 'package:safe_opensig/shared/widgets/network_logo.dart';
+
+class NetworkConfigOverrideScreen extends StatefulWidget {
+  final int chainId;
+
+  const NetworkConfigOverrideScreen({super.key, required this.chainId});
+
+  @override
+  State<NetworkConfigOverrideScreen> createState() =>
+      _NetworkConfigOverrideScreenState();
+}
+
+class _NetworkConfigOverrideScreenState
+    extends State<NetworkConfigOverrideScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late Network _network;
+  bool _isChecking = false;
+
+  late TextEditingController _primaryUrlController;
+  late TextEditingController _explorerUrlController;
+  final List<TextEditingController> _secondaryUrlControllers = [];
+
+  // Chain ID verification state: url -> null (not checked), true (ok), false (failed)
+  final Map<String, bool?> _chainIdResults = {};
+  bool _chainIdChecked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _network = getDefaultNetwork(widget.chainId);
+
+    final existing = NetworkConfigBox.getConfig(widget.chainId);
+
+    _primaryUrlController = TextEditingController(
+      text: existing?.primaryNodeUrl ?? '',
+    );
+    _explorerUrlController = TextEditingController(
+      text: existing?.explorerUrl ?? '',
+    );
+
+    if (existing != null) {
+      for (final url in existing.secondaryNodeUrls) {
+        _secondaryUrlControllers.add(TextEditingController(text: url));
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _primaryUrlController.dispose();
+    _explorerUrlController.dispose();
+    for (final c in _secondaryUrlControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addSecondaryUrl() {
+    setState(() {
+      _secondaryUrlControllers.add(TextEditingController());
+    });
+  }
+
+  void _removeSecondaryUrl(int index) {
+    setState(() {
+      _secondaryUrlControllers[index].dispose();
+      _secondaryUrlControllers.removeAt(index);
+    });
+  }
+
+  Future<bool> _showDebugTraceWarningDialog() async {
+    final theme = Theme.of(context);
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            icon: const Icon(
+              Icons.warning_amber_rounded,
+              color: Colors.amber,
+              size: 40,
+            ),
+            title: const Text('Simulation Not Supported'),
+            content: Text(
+              'This RPC node does not appear to support debug_traceCall, '
+              'which is required for transaction simulation.\n\n'
+              'You can still save this configuration, but simulation '
+              'will not work with this node.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Save Anyway'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  Future<bool> _showDuplicateNodesWarningDialog(int duplicatesRemoved) async {
+    final theme = Theme.of(context);
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            icon: const Icon(
+              Icons.warning_amber_rounded,
+              color: Colors.amber,
+              size: 40,
+            ),
+            title: const Text('Duplicate Nodes Detected'),
+            content: Text(
+              '$duplicatesRemoved duplicate secondary node URL(s) will be '
+              'removed before saving. Duplicates of the primary node or of '
+              'other secondary nodes provide no additional verification.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Go Back'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Save Anyway'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  Future<void> _verifyAllChainIds() async {
+    final primaryUrl = _primaryUrlController.text.trim();
+    final allUrls = <String>[
+      if (primaryUrl.isNotEmpty) primaryUrl,
+      ..._secondaryUrlControllers
+          .map((c) => c.text.trim())
+          .where((u) => u.isNotEmpty),
+    ];
+
+    setState(() {
+      _isChecking = true;
+      _chainIdResults.clear();
+      _chainIdChecked = false;
+    });
+
+    final futures = <Future<void>>[];
+    for (final url in allUrls) {
+      futures.add(
+        Utilities.verifyChainId(url, widget.chainId).then((ok) {
+          if (mounted) {
+            setState(() => _chainIdResults[url] = ok);
+          }
+        }),
+      );
+    }
+    await Future.wait(futures);
+
+    if (mounted) {
+      setState(() {
+        _isChecking = false;
+        _chainIdChecked = true;
+      });
+    }
+  }
+
+  bool get _primaryChainIdFailed {
+    final url = _primaryUrlController.text.trim();
+    return _chainIdChecked && _chainIdResults[url] == false;
+  }
+
+  List<String> get _failedSecondaryUrls {
+    if (!_chainIdChecked) return [];
+    return _secondaryUrlControllers
+        .map((c) => c.text.trim())
+        .where((url) => url.isNotEmpty && _chainIdResults[url] == false)
+        .toList();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    // Step 1: Verify chain IDs for all RPC URLs
+    await _verifyAllChainIds();
+    if (!mounted) return;
+
+    // Block save if primary node failed chain ID check
+    if (_primaryChainIdFailed) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Primary node failed chain ID verification. '
+            'Please replace it before saving.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    final primaryUrl = _primaryUrlController.text.trim();
+
+    // Step 2: Check debug_traceCall support on primary
+    setState(() => _isChecking = true);
+    try {
+      final supported = await Utilities.checkDebugTraceCallSupport(primaryUrl);
+      if (!supported && mounted) {
+        setState(() => _isChecking = false);
+        final proceed = await _showDebugTraceWarningDialog();
+        if (!proceed) return;
+      }
+    } finally {
+      if (mounted) setState(() => _isChecking = false);
+    }
+
+    // Collect and deduplicate secondary URLs, excluding chain ID failures
+    final failedUrls = _failedSecondaryUrls.toSet();
+    final allSecondary = _secondaryUrlControllers
+        .map((c) => c.text.trim())
+        .where((url) => url.isNotEmpty && !failedUrls.contains(url))
+        .toList();
+
+    final seen = <String>{primaryUrl};
+    final deduplicatedSecondary = <String>[
+      for (final url in allSecondary)
+        if (seen.add(url)) url,
+    ];
+
+    final duplicatesRemoved = allSecondary.length - deduplicatedSecondary.length;
+    if (duplicatesRemoved > 0 && mounted) {
+      final proceed = await _showDuplicateNodesWarningDialog(duplicatesRemoved);
+      if (!proceed) return;
+    }
+
+    final config = CustomNetworkConfig(
+      chainId: widget.chainId,
+      primaryNodeUrl: primaryUrl,
+      secondaryNodeUrls: deduplicatedSecondary,
+      explorerUrl: _explorerUrlController.text.trim().isEmpty
+          ? null
+          : _explorerUrlController.text.trim(),
+    );
+
+    await NetworkConfigBox.setConfig(config);
+    if (mounted) {
+      final discardedCount = failedUrls.length;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            discardedCount > 0
+                ? 'Configuration saved ($discardedCount node(s) discarded due to chain ID mismatch)'
+                : 'Configuration saved',
+          ),
+        ),
+      );
+      context.pop();
+    }
+  }
+
+  static const _inputBorderRadius = 12.0;
+
+  InputDecoration _styledInputDecoration({
+    required String hintText,
+    required IconData prefixIcon,
+    String? helperText,
+  }) {
+    return InputDecoration(
+      hintText: hintText,
+      helperText: helperText,
+      prefixIcon: Icon(prefixIcon, size: 20),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(_inputBorderRadius),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(_inputBorderRadius),
+        borderSide: BorderSide(color: Theme.of(context).dividerColor),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(_inputBorderRadius),
+        borderSide: BorderSide(
+          color: Theme.of(context).colorScheme.primary,
+          width: 2,
+        ),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(_inputBorderRadius),
+        borderSide: BorderSide(color: Theme.of(context).colorScheme.error),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(_inputBorderRadius),
+        borderSide: BorderSide(
+          color: Theme.of(context).colorScheme.error,
+          width: 2,
+        ),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Override Configuration'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Form(
+              key: _formKey,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildNetworkHeader(theme),
+                    const SizedBox(height: ThemeConfig.spacingLarge),
+                    _buildWarningCard(theme),
+                    const SizedBox(height: ThemeConfig.spacingLarge),
+                    _buildSectionLabel(
+                      theme,
+                      'Primary node',
+                      infoText:
+                          'The primary node is used to fetch the state of the '
+                          'blockchain before simulation. It must support '
+                          'debug_traceCall for transaction simulation to work.',
+                    ),
+                    const SizedBox(height: ThemeConfig.spacingSmall),
+                    _buildPrimaryNodeField(theme),
+                    const SizedBox(height: ThemeConfig.spacingLarge),
+                    _buildSectionLabel(
+                      theme,
+                      'Secondary nodes',
+                      infoText:
+                          'Secondary nodes are used to independently verify, '
+                          'through Merkle tree proofs, that the state fetched '
+                          'from the primary node is correct. The more secondary '
+                          'nodes you add, the stronger the verification.',
+                    ),
+                    const SizedBox(height: ThemeConfig.spacingSmall),
+                    _buildSecondaryNodesSection(theme),
+                    const SizedBox(height: ThemeConfig.spacingLarge),
+                    _buildSectionLabel(theme, 'Block explorer'),
+                    const SizedBox(height: ThemeConfig.spacingSmall),
+                    _buildExplorerField(theme),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // Bottom actions
+          _buildBottomActions(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNetworkHeader(ThemeData theme) {
+    return Row(
+      children: [
+        NetworkLogo(network: _network, size: 32),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _network.name,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                'Chain ID: ${_network.chainId}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.textTheme.bodySmall?.color
+                      ?.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildWarningCard(ThemeData theme) {
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      color: Colors.amber.withValues(alpha: 0.1),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: Colors.amber.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(Icons.warning_amber_rounded, size: 20, color: Colors.amber),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Advanced Configuration',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Changing the default node configuration can break '
+                    'transaction simulation and state verification. '
+                    'Only proceed if you know what you are doing.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(ThemeData theme, String label, {String? infoText}) {
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      letterSpacing: 0.5,
+      color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
+    );
+    if (infoText == null) {
+      return Text(label, style: labelStyle);
+    }
+    return Row(
+      children: [
+        Text(label, style: labelStyle),
+        const SizedBox(width: 4),
+        GestureDetector(
+          onTap: () => _showInfoDialog(label, infoText),
+          child: Icon(
+            Icons.info_outline,
+            size: 14,
+            color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.4),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showInfoDialog(String title, String body) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Text(title),
+        content: Text(body),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPrimaryNodeField(ThemeData theme) {
+    final url = _primaryUrlController.text.trim();
+    final chainResult = _chainIdChecked ? _chainIdResults[url] : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextFormField(
+          controller: _primaryUrlController,
+          onChanged: (_) => _resetChainIdCheck(),
+          decoration: _styledInputDecoration(
+            hintText: 'https://your-node-url.com',
+            prefixIcon: Icons.circle,
+          ).copyWith(
+            prefixIcon: Icon(
+              Icons.circle,
+              size: 10,
+              color: theme.colorScheme.primary,
+            ),
+            prefixIconConstraints: const BoxConstraints(
+              minWidth: 32,
+              minHeight: 0,
+            ),
+            suffixIcon: _buildChainIdStatusIcon(chainResult),
+          ),
+          keyboardType: TextInputType.url,
+          validator: (value) => value?.validateHttpsUrl(),
+        ),
+        if (chainResult == false)
+          Padding(
+            padding: const EdgeInsets.only(top: 6, left: 4),
+            child: Row(
+              children: [
+                Icon(Icons.error_outline, size: 14, color: theme.colorScheme.error),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'Chain ID mismatch or unreachable. Replace this URL.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _resetChainIdCheck() {
+    if (_chainIdChecked) {
+      setState(() {
+        _chainIdChecked = false;
+        _chainIdResults.clear();
+      });
+    }
+  }
+
+  Widget? _buildChainIdStatusIcon(bool? result) {
+    if (result == null) return null;
+    if (result) {
+      return const Icon(Icons.check_circle, color: Colors.green, size: 20);
+    }
+    return const Icon(Icons.cancel, color: Colors.red, size: 20);
+  }
+
+  Widget _buildSecondaryNodesSection(ThemeData theme) {
+    return Column(
+      children: [
+        ..._secondaryUrlControllers.asMap().entries.map((entry) {
+          final index = entry.key;
+          final controller = entry.value;
+          final url = controller.text.trim();
+          final chainResult = _chainIdChecked ? _chainIdResults[url] : null;
+
+          return Padding(
+            padding: EdgeInsets.only(
+              bottom: index < _secondaryUrlControllers.length - 1
+                  ? ThemeConfig.spacingSmall
+                  : 0,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: controller,
+                        onChanged: (_) => _resetChainIdCheck(),
+                        decoration: _styledInputDecoration(
+                          hintText: 'https://secondary-node.com',
+                          prefixIcon: Icons.circle,
+                        ).copyWith(
+                          prefixIcon: Icon(
+                            Icons.circle,
+                            size: 10,
+                            color: Colors.amber.shade700,
+                          ),
+                          prefixIconConstraints: const BoxConstraints(
+                            minWidth: 32,
+                            minHeight: 0,
+                          ),
+                          suffixIcon: _buildChainIdStatusIcon(chainResult),
+                        ),
+                        keyboardType: TextInputType.url,
+                        validator: (value) =>
+                            value?.validateHttpsUrl(required: true),
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    IconButton(
+                      icon: Icon(
+                        Icons.delete_outline,
+                        color: theme.colorScheme.error,
+                        size: 20,
+                      ),
+                      onPressed: () => _removeSecondaryUrl(index),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ],
+                ),
+                if (chainResult == false)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4, left: 4, bottom: 4),
+                    child: Text(
+                      'Will be discarded — chain ID mismatch or unreachable',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: Colors.amber.shade700,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          );
+        }),
+        if (_secondaryUrlControllers.isNotEmpty)
+          const SizedBox(height: ThemeConfig.spacingSmall),
+        // Add button
+        OutlinedButton.icon(
+          onPressed: _addSecondaryUrl,
+          icon: const Icon(Icons.add, size: 18),
+          label: const Text('Add Secondary Node'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildExplorerField(ThemeData theme) {
+    return TextFormField(
+      controller: _explorerUrlController,
+      decoration: _styledInputDecoration(
+        hintText: 'e.g., https://etherscan.io',
+        prefixIcon: Icons.explore_outlined,
+      ),
+      keyboardType: TextInputType.url,
+      validator: (value) => value?.validateHttpsUrl(required: false)
+    );
+  }
+
+  Widget _buildBottomActions(ThemeData theme) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          ThemeConfig.spacingMedium,
+          ThemeConfig.spacingSmall,
+          ThemeConfig.spacingMedium,
+          ThemeConfig.spacingMedium,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _isChecking ? null : _save,
+                child: _isChecking
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : const Text('Save Network Configuration'),
+              ),
+            ),
+            const SizedBox(height: 4),
+            TextButton(
+              onPressed: () => context.pop(),
+              child: Text(
+                'Cancel Changes',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/network_config_screen.dart
+++ b/lib/features/settings/network_config_screen.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
+import 'package:safe_opensig/core/theme/theme_config.dart';
+import 'package:safe_opensig/shared/constants/event_bus.dart';
+import 'package:safe_opensig/shared/constants/network_constants.dart';
+import 'package:safe_opensig/shared/models/custom_network_config.dart';
+import 'package:safe_opensig/shared/models/network_model.dart';
+import 'package:safe_opensig/shared/widgets/network_logo.dart';
+
+class NetworkConfigScreen extends StatefulWidget {
+  final int chainId;
+
+  const NetworkConfigScreen({super.key, required this.chainId});
+
+  @override
+  State<NetworkConfigScreen> createState() => _NetworkConfigScreenState();
+}
+
+class _NetworkConfigScreenState extends State<NetworkConfigScreen> {
+  late Network _network;
+  late StreamSubscription _configChangeSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _network = getDefaultNetwork(widget.chainId);
+    _configChangeSubscription = eventBus.on<OnNodeConfigChange>().listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _configChangeSubscription.cancel();
+    super.dispose();
+  }
+
+  bool get _isCustom => NetworkConfigBox.hasCustomConfig(widget.chainId);
+
+  CustomNetworkConfig? get _customConfig =>
+      NetworkConfigBox.getConfig(widget.chainId);
+
+  Future<void> _revertToDefault() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Revert to Recommended'),
+        content: const Text(
+          'This will remove your custom node configuration and revert to the recommended defaults.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            child: const Text('Revert'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+    await NetworkConfigBox.removeConfig(widget.chainId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isCustom = _isCustom;
+    final config = _customConfig;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Network Configuration'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildNetworkCard(theme, isCustom),
+
+                  if (isCustom && config != null) ...[
+                    const SizedBox(height: ThemeConfig.spacingLarge),
+                    _buildCustomConfigDetails(theme, config),
+                  ],
+
+                  const SizedBox(height: ThemeConfig.spacingXLarge),
+                  if (!isCustom)
+                    _buildSecurityBadge(theme),
+                ],
+              ),
+            ),
+          ),
+          _buildBottomActions(theme, isCustom),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNetworkCard(ThemeData theme, bool isCustom) {
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: theme.dividerColor, width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                NetworkLogo(network: _network, size: 40),
+                const SizedBox(width: 14),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'NETWORK CONFIGURATION',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.textTheme.bodySmall?.color
+                            ?.withValues(alpha: 0.5),
+                        letterSpacing: 1.0,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _network.name,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    isCustom
+                        ? 'Using custom node configuration. Override settings can be edited.'
+                        : 'This configuration is optimized for high security and performance using verified nodes.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.textTheme.bodySmall?.color
+                          ?.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCustomConfigDetails(ThemeData theme, CustomNetworkConfig config) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Primary RPC URL
+        _buildSectionLabel(theme, 'Primary RPC URL'),
+        const SizedBox(height: ThemeConfig.spacingSmall),
+        _buildUrlRow(theme, config.primaryNodeUrl),
+
+        // Secondary Nodes
+        if (config.secondaryNodeUrls.isNotEmpty) ...[
+          const SizedBox(height: ThemeConfig.spacingLarge),
+          _buildSectionLabel(theme, 'Secondary Nodes'),
+          const SizedBox(height: ThemeConfig.spacingSmall),
+          ...config.secondaryNodeUrls.map(
+            (url) => Padding(
+              padding: const EdgeInsets.only(bottom: ThemeConfig.spacingSmall),
+              child: _buildUrlRow(theme, url),
+            ),
+          ),
+        ],
+
+        // Block Explorer
+        if (config.explorerUrl != null &&
+            config.explorerUrl!.isNotEmpty) ...[
+          const SizedBox(height: ThemeConfig.spacingLarge),
+          _buildSectionLabel(theme, 'Block Explorer URL'),
+          const SizedBox(height: ThemeConfig.spacingSmall),
+          _buildUrlRow(theme, config.explorerUrl!),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSectionLabel(ThemeData theme, String label) {
+    return Text(
+      label,
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
+        letterSpacing: 0.5,
+      ),
+    );
+  }
+
+  Widget _buildUrlRow(ThemeData theme, String url) {
+    return Text(
+      url,
+      style: theme.textTheme.bodyMedium,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+
+  Widget _buildSecurityBadge(ThemeData theme) {
+    final mutedColor =
+        theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5);
+
+    return Column(
+      children: [
+        Icon(
+          Icons.verified_user,
+          size: 32,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(height: 10),
+        Text(
+          'Recommended Configuration Active',
+          style: theme.textTheme.titleSmall?.copyWith(
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 14),
+        Row(
+          children: [
+            Expanded(
+              child: _BadgeItem(
+                icon: Icons.hub_outlined,
+                label: '3+ Independent Nodes',
+                description: 'for State verification',
+                color: theme.colorScheme.primary,
+                theme: theme,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              // todo review this badge whether should be kept or not
+              child: _BadgeItem(
+                icon: Icons.all_inclusive,
+                label: 'Unlimited',
+                description: 'Simulations / mo',
+                color: theme.colorScheme.primary,
+                theme: theme,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        Text(
+          'Multi-node consensus ensures trust-minimized state verification for every transaction',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodySmall?.copyWith(color: mutedColor),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBottomActions(ThemeData theme, bool isCustom) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          ThemeConfig.spacingMedium,
+          ThemeConfig.spacingSmall,
+          ThemeConfig.spacingMedium,
+          ThemeConfig.spacingMedium,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  context.go(
+                    '/settings/node-settings/configure/override',
+                    extra: widget.chainId,
+                  );
+                },
+                icon: Icon(
+                  isCustom ? Icons.edit : Icons.tune,
+                  size: 20,
+                ),
+                label: Text(
+                  isCustom ? 'Edit Configuration' : 'Override Configuration',
+                ),
+              ),
+            ),
+            if (isCustom) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: _revertToDefault,
+                  icon: const Icon(Icons.refresh, size: 18),
+                  label: const Text('Revert to Recommended'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: theme.colorScheme.error,
+                    side: BorderSide(
+                      color: theme.colorScheme.error.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            Text(
+              isCustom
+                  ? 'Custom nodes are active for this network'
+                  : 'Overriding configuration is not recommended for most users',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.textTheme.bodySmall?.color
+                    ?.withValues(alpha: 0.4),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BadgeItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String description;
+  final Color color;
+  final ThemeData theme;
+
+  const _BadgeItem({
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.color,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 115,
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 22, color: color),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.textTheme.bodySmall?.color
+                  ?.withValues(alpha: 0.6),
+              fontSize: 11,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/networks_listing_configuration_screen.dart
+++ b/lib/features/settings/networks_listing_configuration_screen.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
+import 'package:safe_opensig/core/theme/theme_config.dart';
+import 'package:safe_opensig/shared/constants/event_bus.dart';
+import 'package:safe_opensig/shared/constants/network_constants.dart';
+import 'package:safe_opensig/shared/models/network_model.dart';
+import 'package:safe_opensig/shared/widgets/network_logo.dart';
+
+class NetworksListingConfigScreen extends StatefulWidget {
+  const NetworksListingConfigScreen({super.key});
+
+  @override
+  State<NetworksListingConfigScreen> createState() => _NetworksListingConfigScreenState();
+}
+
+class _NetworksListingConfigScreenState extends State<NetworksListingConfigScreen> {
+  late StreamSubscription _configChangeSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _configChangeSubscription = eventBus.on<OnNodeConfigChange>().listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _configChangeSubscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final networks = availableNetworks.values.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Networks Configurations', style: TextStyle(fontSize: 20),),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+        itemCount: networks.length,
+        itemBuilder: (context, index) {
+          final network = networks[index];
+          return Column(
+            children: [
+              _NetworkCard(network: network),
+              if (index < (networks.length-1))
+                Divider()
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _NetworkCard extends StatelessWidget {
+  final Network network;
+
+  const _NetworkCard({required this.network});
+
+  @override
+  Widget build(BuildContext context) {
+    final isCustom = NetworkConfigBox.hasCustomConfig(network.chainId);
+
+    return InkWell(
+      onTap: () {
+        context.go('/settings/node-settings/configure', extra: network.chainId);
+      },
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: ThemeConfig.spacingSmall, vertical: ThemeConfig.spacingXSmall),
+        child: Row(
+          children: [
+            NetworkLogo(network: network, size: 28),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    network.name,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Chain ID: ${network.chainId}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).textTheme.bodySmall?.color?.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            _StatusChip(isCustom: isCustom),
+            const SizedBox(width: 4),
+            Icon(
+              Icons.chevron_right,
+              size: 20,
+              color: Theme.of(context).textTheme.bodySmall?.color?.withValues(alpha: 0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  final bool isCustom;
+
+  const _StatusChip({required this.isCustom});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: isCustom
+            ? Theme.of(context).colorScheme.surfaceContainerHighest
+            : Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        isCustom ? 'Custom' : 'Default',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: isCustom
+              ? Theme.of(context).textTheme.labelSmall?.color
+              : Theme.of(context).colorScheme.onPrimaryContainer
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,0 +1,351 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:safe_opensig/core/theme/theme_config.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  static const _docsUrl = 'https://github.com/candidelabs/safe-opensig';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mutedColor =
+        theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => context.go('/accounts')),
+        title: const Text('Settings'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+        child: Column(
+          children: [
+            _NetworkConfigCard(theme: theme),
+            const SizedBox(height: ThemeConfig.spacingSmall),
+            _SettingsTile(
+              icon: Icons.description_outlined,
+              title: 'Documentation',
+              trailing: Icon(Icons.open_in_new, size: 18, color: mutedColor),
+              onTap: () => _openDocs(),
+            ),
+            const SizedBox(height: ThemeConfig.spacingSmall),
+            _SettingsTile(
+              icon: Icons.info_outline,
+              title: 'About Safe Opensig',
+              trailing: Text(
+                'v1.0.0',
+                style: theme.textTheme.bodySmall?.copyWith(color: mutedColor),
+              ),
+              onTap: () => _showAbout(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openDocs() async {
+    final uri = Uri.parse(_docsUrl);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  void _showAbout(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => const _AboutDialog(),
+    );
+  }
+}
+
+class _NetworkConfigCard extends StatelessWidget {
+  final ThemeData theme;
+
+  const _NetworkConfigCard({required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: theme.dividerColor, width: 1),
+      ),
+      child: InkWell(
+        onTap: () => context.go('/settings/node-settings'),
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.all(ThemeConfig.spacingMedium),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  Icons.hub_outlined,
+                  color: theme.colorScheme.primary,
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Network Configuration',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Manage node endpoints and protocol RPCs',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.textTheme.bodySmall?.color
+                            ?.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                size: 20,
+                color: theme.textTheme.bodySmall?.color
+                    ?.withValues(alpha: 0.5),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AboutDialog extends StatelessWidget {
+  const _AboutDialog();
+
+  static const _githubUrl = 'https://github.com/candidelabs/safe-opensig';
+  static const _xUrl = 'https://x.com/candidelabs';
+  static const _websiteUrl = 'https://candide.dev/opensig';
+
+  static const _features = [
+    ('Decode & verify Safe transactions before signing', Icons.verified_outlined),
+    ('Simulate transactions with EVM tracing locally', Icons.play_circle_outline),
+    ('Multi-node state verification for trust minimization', Icons.hub_outlined),
+    ('Hardware wallet screen preview (Ledger)', Icons.security_outlined),
+    ('13+ EVM chains supported', Icons.language),
+  ];
+
+  Future<void> _open(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mutedColor =
+        theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5);
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Image.asset('assets/ic_logo.png', width: 56, height: 56),
+              const SizedBox(height: 12),
+              Text(
+                'Safe OpenSig',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'v1.0.0',
+                style: theme.textTheme.bodySmall?.copyWith(color: mutedColor),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Eliminate blind signing for Safe multisig transactions',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.textTheme.bodySmall?.color
+                      ?.withValues(alpha: 0.7),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Features',
+                  style: theme.textTheme.titleSmall,
+                ),
+              ),
+              const SizedBox(height: 8),
+              ..._features.map((f) => Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(f.$2, size: 16, color: theme.colorScheme.primary),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            f.$1,
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )),
+              const SizedBox(height: 16),
+              Divider(height: 1, color: theme.dividerColor),
+              const SizedBox(height: 14),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _SocialButton(
+                    icon: Icons.code,
+                    label: 'GitHub',
+                    onTap: () => _open(_githubUrl),
+                  ),
+                  const SizedBox(width: 16),
+                  _SocialButton(
+                    icon: Icons.alternate_email,
+                    label: 'X',
+                    onTap: () => _open(_xUrl),
+                  ),
+                  const SizedBox(width: 16),
+                  _SocialButton(
+                    icon: Icons.public,
+                    label: 'Website',
+                    onTap: () => _open(_websiteUrl),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Developed by Candide Labs',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: mutedColor,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Close'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SocialButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _SocialButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 22, color: theme.colorScheme.primary),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.textTheme.bodySmall?.color
+                    ?.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const _SettingsTile({
+    required this.icon,
+    required this.title,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: theme.dividerColor, width: 1),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: [
+              Icon(icon, size: 20, color: theme.colorScheme.onSurface),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (trailing != null) trailing!,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
+++ b/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
@@ -12,9 +12,14 @@ import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_ca
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_calldata_input.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_json_guide_sheet.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_json_input.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
 import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+import 'package:safe_opensig/shared/utils/utilities.dart';
 import 'package:version/version.dart';
+
+enum _SimulationDialogResult { goBack, skipToHashes, useDefault }
+enum _NoSecondaryNodesResult { goBack, continueAnyway, useDefault }
 
 class SafeTransactionFormScreen extends StatefulWidget {
   final SafeAccount safeAccount;
@@ -83,10 +88,220 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
       return;
     }
 
+    if (NetworkConfigBox.hasCustomConfig(widget.safeAccount.chainId)) {
+      final config = NetworkConfigBox.getConfig(widget.safeAccount.chainId)!;
+      cancelLoad = BotToast.showLoading();
+      final supported = await Utilities.checkDebugTraceCallSupport(config.primaryNodeUrl);
+      cancelLoad();
+      if (!mounted) return;
+
+      if (!supported) {
+        final result = await _showSimulationUnavailableDialog();
+        if (!mounted) return;
+        switch (result) {
+          case _SimulationDialogResult.goBack:
+            return;
+          case _SimulationDialogResult.skipToHashes:
+            GoRouter.of(context).push(
+              "/verify-transaction/hashes",
+              extra: (widget.safeAccount, safeTransaction!),
+            );
+            return;
+          case _SimulationDialogResult.useDefault:
+            await NetworkConfigBox.removeConfig(widget.safeAccount.chainId);
+            break; // fall through to simulation navigation
+        }
+      } else if (config.secondaryNodeUrls.isEmpty) {
+        final result = await _showNoSecondaryNodesDialog();
+        if (!mounted) return;
+        switch (result) {
+          case _NoSecondaryNodesResult.goBack:
+            return;
+          case _NoSecondaryNodesResult.continueAnyway:
+            break; // fall through to simulation navigation
+          case _NoSecondaryNodesResult.useDefault:
+            await NetworkConfigBox.removeConfig(widget.safeAccount.chainId);
+            break; // fall through to simulation navigation
+        }
+      }
+    }
+
     GoRouter.of(context).push(
       "/verify-transaction/simulation-loading",
       extra: (widget.safeAccount, safeTransaction!),
     );
+  }
+
+  Future<_SimulationDialogResult> _showSimulationUnavailableDialog() async {
+    final theme = Theme.of(context);
+    return await showDialog<_SimulationDialogResult>(
+          context: context,
+          builder: (context) => AlertDialog(
+            insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+            contentPadding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+            titlePadding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+            iconPadding: const EdgeInsets.only(top: 16),
+            actionsPadding: EdgeInsets.zero,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            icon: const Icon(
+              Icons.warning_amber_rounded,
+              color: Colors.amber,
+              size: 36,
+            ),
+            title: Text(
+              'Simulation Not Available',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Your custom RPC node does not support '
+                  'debug_traceCall, which is required for '
+                  'transaction simulation.',
+                  style: theme.textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.of(context).pop(_SimulationDialogResult.useDefault),
+                    icon: const Icon(Icons.restart_alt_rounded, size: 18),
+                    label: const Text('Use Default Config & Simulate'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      side: BorderSide(color: theme.colorScheme.primary),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.of(context).pop(_SimulationDialogResult.skipToHashes),
+                    icon: const Icon(Icons.skip_next_rounded, size: 18),
+                    label: const Text('Skip to Hashes'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      side: BorderSide(color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton(
+                    onPressed: () => Navigator.of(context).pop(_SimulationDialogResult.goBack),
+                    child: Text(
+                      'Go Back',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ) ??
+        _SimulationDialogResult.goBack;
+  }
+
+  Future<_NoSecondaryNodesResult> _showNoSecondaryNodesDialog() async {
+    final theme = Theme.of(context);
+    return await showDialog<_NoSecondaryNodesResult>(
+          context: context,
+          builder: (context) => AlertDialog(
+            insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+            contentPadding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+            titlePadding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+            iconPadding: const EdgeInsets.only(top: 16),
+            actionsPadding: EdgeInsets.zero,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            icon: const Icon(
+              Icons.info_outline_rounded,
+              color: Colors.amber,
+              size: 36,
+            ),
+            title: Text(
+              'No State Verification',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Your custom configuration has no secondary '
+                  'nodes. Without multiple independent nodes, '
+                  'state verification cannot cross-check data, '
+                  'reducing the trust assumptions of the '
+                  'simulation.',
+                  style: theme.textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.of(context).pop(_NoSecondaryNodesResult.useDefault),
+                    icon: const Icon(Icons.restart_alt_rounded, size: 18),
+                    label: const Text('Use Default Config & Validate'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      side: BorderSide(color: theme.colorScheme.primary),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.of(context).pop(_NoSecondaryNodesResult.continueAnyway),
+                    icon: const Icon(Icons.play_arrow_rounded, size: 18),
+                    label: const Text('Continue Anyway'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      side: BorderSide(color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton(
+                    onPressed: () => Navigator.of(context).pop(_NoSecondaryNodesResult.goBack),
+                    child: Text(
+                      'Go Back',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ) ??
+        _NoSecondaryNodesResult.goBack;
   }
 
   @override

--- a/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/safe_tx_simulation_screen.dart
@@ -16,6 +16,7 @@ import 'package:safe_opensig/shared/models/simulation/token_allowance.dart';
 import 'package:safe_opensig/shared/models/simulation/token_transfer.dart';
 import 'package:safe_opensig/shared/models/simulation/warning_transaction.dart';
 import 'package:safe_opensig/shared/utils/utilities.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:safe_opensig/shared/widgets/trust_minimized_note.dart';
 import 'package:safe_opensig/shared/widgets/address_widget.dart';
 import 'package:wallet/wallet.dart';
@@ -137,8 +138,11 @@ class _SafeTxSimulationScreenState extends State<SafeTxSimulationScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            TrustMinimizedNote(),
-            const SizedBox(height: 16),
+            if (!NetworkConfigBox.hasCustomConfig(widget.safeAccount.chainId) ||
+                (NetworkConfigBox.getConfig(widget.safeAccount.chainId)?.secondaryNodeUrls.isNotEmpty ?? false)) ...[
+              TrustMinimizedNote(),
+              const SizedBox(height: 16),
+            ],
             if (widget.transaction.hasNonceMismatch) ...[
               Card(
                 color: Colors.orange.shade600.withAlpha((255*0.1).floor()),

--- a/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
 import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
 import 'package:safe_opensig/shared/models/simulation/simulation_phase.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:safe_opensig/shared/widgets/trust_minimized_note.dart';
 
 // Toggle this to add a delay between phases for better visibility
@@ -268,12 +269,19 @@ class _SimulationLoadingScreenState extends State<SimulationLoadingScreen> {
                   ),
                 ),
                 const SizedBox(height: 32),
-                _PhaseChecklist(currentPhase: _currentPhase),
-                const SizedBox(height: 24),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 28.0),
-                  child: TrustMinimizedNote(),
+                _PhaseChecklist(
+                  currentPhase: _currentPhase,
+                  stateVerificationSkipped:
+                      NetworkConfigBox.hasCustomConfig(widget.safeAccount.chainId) &&
+                      (NetworkConfigBox.getConfig(widget.safeAccount.chainId)?.secondaryNodeUrls.isEmpty ?? true),
                 ),
+                const SizedBox(height: 24),
+                if (!NetworkConfigBox.hasCustomConfig(widget.safeAccount.chainId) ||
+                    (NetworkConfigBox.getConfig(widget.safeAccount.chainId)?.secondaryNodeUrls.isNotEmpty ?? false))
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 28.0),
+                    child: TrustMinimizedNote(),
+                  ),
                 const SizedBox(height: 32),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 28.0),
@@ -364,8 +372,9 @@ class _PhaseIcon extends StatelessWidget {
 
 class _PhaseChecklist extends StatelessWidget {
   final SimulationPhase currentPhase;
+  final bool stateVerificationSkipped;
 
-  const _PhaseChecklist({required this.currentPhase});
+  const _PhaseChecklist({required this.currentPhase, this.stateVerificationSkipped = false});
 
   bool _isPhaseCompleted(SimulationPhase phase) {
     return phase.index <= currentPhase.index;
@@ -394,6 +403,10 @@ class _PhaseChecklist extends StatelessWidget {
         final isCompleted = _isPhaseCompleted(phase);
         final isCurrent = _isCurrentPhase(phase);
         final isLast = index == phases.length - 1;
+        final isWarn = phase == SimulationPhase.verifyingState
+            && stateVerificationSkipped
+            && isCompleted
+            && !isCurrent;
 
         return Row(
           mainAxisSize: MainAxisSize.min,
@@ -401,18 +414,22 @@ class _PhaseChecklist extends StatelessWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
               decoration: BoxDecoration(
-                color: isCurrent
-                    ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.15)
-                    : (isCompleted
-                        ? Colors.green.withValues(alpha: 0.15)
-                        : Colors.grey.withValues(alpha: 0.1)),
+                color: isWarn
+                    ? Colors.amber.withValues(alpha: 0.15)
+                    : isCurrent
+                        ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.15)
+                        : (isCompleted
+                            ? Colors.green.withValues(alpha: 0.15)
+                            : Colors.grey.withValues(alpha: 0.1)),
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: isCurrent
-                      ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.4)
-                      : (isCompleted
-                          ? Colors.green.withValues(alpha: 0.4)
-                          : Colors.grey.withValues(alpha: 0.3)),
+                  color: isWarn
+                      ? Colors.amber.withValues(alpha: 0.4)
+                      : isCurrent
+                          ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.4)
+                          : (isCompleted
+                              ? Colors.green.withValues(alpha: 0.4)
+                              : Colors.grey.withValues(alpha: 0.3)),
                   width: 1,
                 ),
               ),
@@ -430,9 +447,13 @@ class _PhaseChecklist extends StatelessWidget {
                             ),
                           )
                         : Icon(
-                            isCompleted ? Icons.check_circle : Icons.circle_outlined,
+                            isWarn
+                                ? Icons.warning_amber_rounded
+                                : isCompleted ? Icons.check_circle : Icons.circle_outlined,
                             size: 14,
-                            color: isCompleted ? Colors.green : Colors.grey[600],
+                            color: isWarn
+                                ? Colors.amber
+                                : isCompleted ? Colors.green : Colors.grey[600],
                           ),
                   ),
                   const SizedBox(width: 6),
@@ -441,9 +462,11 @@ class _PhaseChecklist extends StatelessWidget {
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           fontSize: 11,
                           fontWeight: isCurrent ? FontWeight.bold : FontWeight.w500,
-                          color: isCurrent
-                              ? Theme.of(context).colorScheme.primary
-                              : (isCompleted ? Colors.grey[300] : Colors.grey[600]),
+                          color: isWarn
+                              ? Colors.amber[300]
+                              : isCurrent
+                                  ? Theme.of(context).colorScheme.primary
+                                  : (isCompleted ? Colors.grey[300] : Colors.grey[600]),
                         ),
                   ),
                 ],
@@ -455,7 +478,9 @@ class _PhaseChecklist extends StatelessWidget {
                 width: 16,
                 height: 1,
                 margin: const EdgeInsets.symmetric(horizontal: 4),
-                color: isCompleted ? Colors.green.withValues(alpha: 0.4) : Colors.grey.withValues(alpha: 0.3),
+                color: isWarn
+                    ? Colors.amber.withValues(alpha: 0.4)
+                    : isCompleted ? Colors.green.withValues(alpha: 0.4) : Colors.grey.withValues(alpha: 0.3),
               ),
           ],
         );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,10 @@ import 'package:safe_opensig/core/router/app_router.dart';
 import 'package:safe_opensig/core/storage/accounts_box.dart';
 import 'package:safe_opensig/core/storage/migrations/migration_runner.dart';
 import 'package:safe_opensig/core/storage/misc_box.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:safe_opensig/core/storage/theme_box.dart';
+import 'package:safe_opensig/shared/constants/event_bus.dart';
+import 'package:safe_opensig/shared/constants/network_constants.dart';
 import 'package:safe_opensig/core/theme/app_theme.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -28,9 +31,13 @@ void main() async {
   await Future.wait([
     MiscBox.init(),
     ThemeBox.init(),
-    AccountsBox.init()
+    AccountsBox.init(),
+    NetworkConfigBox.init(),
   ]);
   await HiveMigrationRunner.needsMigration();
+
+  rebuildEffectiveNetworks();
+  eventBus.on<OnNodeConfigChange>().listen((_) => rebuildEffectiveNetworks());
 
   // Initialize platform-specific features
   if (!kIsWeb && Platform.isWindows) {

--- a/lib/shared/constants/event_bus.dart
+++ b/lib/shared/constants/event_bus.dart
@@ -22,6 +22,10 @@ enum MigrationStatus {
   FAILED,
 }
 
+class OnNodeConfigChange {
+  const OnNodeConfigChange();
+}
+
 class OnMigrationStatusChange {
   final MigrationStatus status;
   final String message;

--- a/lib/shared/constants/network_constants.dart
+++ b/lib/shared/constants/network_constants.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart';
+import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:web3dart/web3dart.dart';
 
 import '../models/network_model.dart';
 
-var availableNetworks = {
+final _defaultNetworks = {
   // L1s
   1: Network(
     name: 'Ethereum',
@@ -173,3 +174,39 @@ var availableNetworks = {
     logoUri: null,
   ),
 };
+
+Map<int, Network> _effectiveNetworks = {};
+
+Map<int, Network> get availableNetworks => _effectiveNetworks;
+
+void rebuildEffectiveNetworks() {
+  final customConfigs = NetworkConfigBox.getAllConfigs();
+  _effectiveNetworks = _defaultNetworks.map((chainId, defaultNetwork) {
+    final custom = customConfigs[chainId];
+    if (custom == null) return MapEntry(chainId, defaultNetwork);
+
+    final customProviders = [
+      Web3Client(custom.primaryNodeUrl, Client()),
+      ...custom.secondaryNodeUrls.map((url) => Web3Client(url, Client())),
+    ];
+
+    final customExplorers = custom.explorerUrl != null
+        ? [("Custom Explorer", custom.explorerUrl!)]
+        : defaultNetwork.explorers;
+
+    return MapEntry(
+      chainId,
+      Network(
+        name: defaultNetwork.name,
+        chainPrefix: defaultNetwork.chainPrefix,
+        chainId: defaultNetwork.chainId,
+        nativeCurrencySymbol: defaultNetwork.nativeCurrencySymbol,
+        providers: customProviders,
+        explorers: customExplorers,
+        logoUri: defaultNetwork.logoUri,
+      ),
+    );
+  });
+}
+
+Network getDefaultNetwork(int chainId) => _defaultNetworks[chainId]!;

--- a/lib/shared/models/custom_network_config.dart
+++ b/lib/shared/models/custom_network_config.dart
@@ -1,0 +1,30 @@
+class CustomNetworkConfig {
+  final int chainId;
+  final String primaryNodeUrl;
+  final List<String> secondaryNodeUrls;
+  final String? explorerUrl;
+
+  const CustomNetworkConfig({
+    required this.chainId,
+    required this.primaryNodeUrl,
+    this.secondaryNodeUrls = const [],
+    this.explorerUrl,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'chainId': chainId,
+    'primaryNodeUrl': primaryNodeUrl,
+    'secondaryNodeUrls': secondaryNodeUrls,
+    if (explorerUrl != null) 'explorerUrl': explorerUrl,
+  };
+
+  factory CustomNetworkConfig.fromJson(Map<String, dynamic> json) {
+    return CustomNetworkConfig(
+      chainId: json['chainId'] as int,
+      primaryNodeUrl: json['primaryNodeUrl'] as String,
+      secondaryNodeUrls: (json['secondaryNodeUrls'] as List<dynamic>?)
+          ?.cast<String>() ?? [],
+      explorerUrl: json['explorerUrl'] as String?,
+    );
+  }
+}

--- a/lib/shared/utils/extensions/string_extensions.dart
+++ b/lib/shared/utils/extensions/string_extensions.dart
@@ -2,4 +2,23 @@ import 'package:safe_opensig/shared/utils/utilities.dart';
 
 extension StringExtensions on String {
   bool get isNumericOnly => Utilities.hasMatch(this, r'^\d+$');
+
+  String? validateHttpsUrl({bool required = true}) {
+    if (trim().isEmpty) {
+      return required ? 'URL is required' : null;
+    }
+
+    final trimmed = trim();
+
+    if (!trimmed.startsWith('https://')) {
+      return 'URL must start with https://';
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || !uri.hasAuthority || uri.host.isEmpty) {
+      return 'Invalid URL';
+    }
+
+    return null;
+  }
 }

--- a/lib/shared/utils/utilities.dart
+++ b/lib/shared/utils/utilities.dart
@@ -224,6 +224,39 @@ class Utilities {
     }
   }
 
+  static Future<bool> checkEthGetProofSupport(String rpcUrl) async {
+    try {
+      final client = Web3Client(rpcUrl, http.Client());
+      try {
+        final response = await client.makeRPCCall('eth_getProof', [
+          '0x0000000000000000000000000000000000000000',
+          [],
+          'latest',
+        ]).timeout(const Duration(seconds: 7));
+        final result = response as Map<String, dynamic>;
+        return result.containsKey('accountProof');
+      } on RPCError catch (e) {
+        final message = e.message.toLowerCase();
+        const unsupportedPatterns = [
+          'not found',
+          'not available',
+          'not supported',
+          'does not exist',
+          'unsupported',
+          'method not allowed',
+        ];
+        for (final pattern in unsupportedPatterns) {
+          if (message.contains(pattern)) return false;
+        }
+        return true;
+      } finally {
+        client.dispose();
+      }
+    } catch (_) {
+      return false;
+    }
+  }
+
   static Future<bool> checkDebugTraceCallSupport(String rpcUrl) async {
     try {
       final client = Web3Client(rpcUrl, http.Client());

--- a/lib/shared/utils/utilities.dart
+++ b/lib/shared/utils/utilities.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
 
 import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
 import 'package:safe_opensig/shared/utils/abi_utils.dart';
 import 'package:safe_opensig/shared/utils/extensions/string_extensions.dart';
 import 'package:wallet/wallet.dart';
+import 'package:web3dart/json_rpc.dart';
 import 'package:web3dart/web3dart.dart';
 
 class Utilities {
@@ -200,6 +202,80 @@ class Utilities {
   static String _addThousandsSeparators(String number) {
     final regex = RegExp(r'(\d)(?=(\d{3})+(?!\d))');
     return number.replaceAllMapped(regex, (match) => '${match[1]},');
+  }
+
+  static Future<bool> verifyChainId(String rpcUrl, int expectedChainId) async {
+    try {
+      final client = Web3Client(rpcUrl, http.Client());
+      try {
+        final result = await client
+            .makeRPCCall('eth_chainId', [])
+            .timeout(const Duration(seconds: 7));
+        final returnedChainId = int.parse(
+          (result as String).replaceFirst('0x', ''),
+          radix: 16,
+        );
+        return returnedChainId == expectedChainId;
+      } finally {
+        client.dispose();
+      }
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static Future<bool> checkDebugTraceCallSupport(String rpcUrl) async {
+    try {
+      final client = Web3Client(rpcUrl, http.Client());
+      try {
+        final to = "0x573D022940D6f096A8A8EBe718480A35813EE0Fc".toLowerCase();
+        // This RPC call should show that 'to' had a prestate of 0x0000000000000000000000000000000000000000000000000000000000000055 at 0x54ed94d77995e8aae832f82f9581a53db2ba36d621e62e254afb7c4c9c2077ad
+        final _response = await client.makeRPCCall('debug_traceCall', [
+          {
+            "from": "0xD8BB296624f635696Bb7c49dF1a15AB83f320d73",
+            "to": to,
+            "data": "0x09b1483d54ed94d77995e8aae832f82f9581a53db2ba36d621e62e254afb7c4c9c2077ad"
+          },
+          'latest',
+          {
+            "tracer": "prestateTracer",
+            "stateOverrides": {
+              to: {
+                "code": "0x6080604052348015600e575f5ffd5b50600436106026575f3560e01c806309b1483d14602a575b5f5ffd5b60406004803603810190603c91906080565b6042565b005b80546001810182555050565b5f5ffd5b5f819050919050565b6062816052565b8114606b575f5ffd5b50565b5f81359050607a81605b565b92915050565b5f602082840312156092576091604e565b5b5f609d84828501606e565b9150509291505056fea2646970667358221220639c4206c71a8dfa346abcea7182b52a1f27169c71e0d3670483575f9bde013f64736f6c634300081f0033",
+                "stateDiff": {
+                  "0x54ed94d77995e8aae832f82f9581a53db2ba36d621e62e254afb7c4c9c2077ad": "0x0000000000000000000000000000000000000000000000000000000000000055"
+                }
+              }
+            }
+          }
+        ]).timeout(const Duration(seconds: 7));
+        var response = _response as Map<String, dynamic>;
+        if (!response.containsKey(to)) return false;
+        if (!response[to].containsKey("storage")) return false;
+        if (!response[to]["storage"].containsKey("0x54ed94d77995e8aae832f82f9581a53db2ba36d621e62e254afb7c4c9c2077ad")) return false;
+        var storageValue = response[to]["storage"]["0x54ed94d77995e8aae832f82f9581a53db2ba36d621e62e254afb7c4c9c2077ad"];
+        if (storageValue != "0x0000000000000000000000000000000000000000000000000000000000000055") return false;
+        return true;
+      } on RPCError catch (e) {
+        final message = e.message.toLowerCase();
+        const unsupportedPatterns = [
+          'not found',
+          'not available',
+          'not supported',
+          'does not exist',
+          'unsupported',
+          'method not allowed',
+        ];
+        for (final pattern in unsupportedPatterns) {
+          if (message.contains(pattern)) return false;
+        }
+        return true;
+      } finally {
+        client.dispose();
+      }
+    } catch (_) {
+      return false;
+    }
   }
 
 }

--- a/lib/shared/widgets/address_detail_sheet.dart
+++ b/lib/shared/widgets/address_detail_sheet.dart
@@ -2,20 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:blockies/blockies.dart';
 import 'package:safe_opensig/shared/constants/network_constants.dart';
+import 'package:safe_opensig/shared/models/network_model.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:safe_opensig/core/theme/theme_config.dart';
 
 class AddressDetailSheet extends StatelessWidget {
   final String address;
-  final int? chainId;
+  late final Network? network;
   final double blockiesSize;
 
-  const AddressDetailSheet({
-    Key? key,
+  AddressDetailSheet({
+    super.key,
     required this.address,
-    this.chainId,
+    int? chainId,
     this.blockiesSize = 64,
-  }) : super(key: key);
+  }){
+    if (chainId != null){
+      network = availableNetworks[chainId]!;
+    }
+  }
 
   void _handleCopy(BuildContext context) {
     try {
@@ -56,18 +61,16 @@ class AddressDetailSheet extends StatelessWidget {
     }
   }
 
-  String getBlockExplorerUrl(int chainId, String address) {
-    final network = availableNetworks[chainId]!;
-    final baseUrl = network.explorers[0].$2;
+  String? getBlockExplorerUrl(String address) {
+    if (network == null) return null;
+    if (network!.explorers.isEmpty) return null;
+    final baseUrl = network!.explorers[0].$2;
     return '$baseUrl/address/$address';
   }
 
   @override
   Widget build(BuildContext context) {
-    final explorerUrl = chainId != null
-        ? getBlockExplorerUrl(chainId!, address)
-        : null;
-
+    final explorerUrl = getBlockExplorerUrl(address);
     return SafeArea(
       child: Container(
         padding: EdgeInsets.all(ThemeConfig.spacingMedium),

--- a/lib/shared/widgets/network_logo.dart
+++ b/lib/shared/widgets/network_logo.dart
@@ -56,6 +56,29 @@ class NetworkLogo extends StatelessWidget {
   }
 
   Widget _buildNetworkLogoFromUri() {
+    if (network.logoUri == null || network.logoUri?.trim() == ""){
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(50.0),
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: Colors.blue.withValues(alpha: 0.2),
+            shape: BoxShape.circle,
+          ),
+          child: Center(
+            child: Text(
+              network.name.substring(0, 1).toUpperCase(),
+              style: TextStyle(
+                fontSize: size * 0.6,
+                fontWeight: FontWeight.bold,
+                color: Colors.blue,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
     return ClipRRect(
       borderRadius: BorderRadius.circular(50.0),
       child: Image.network(


### PR DESCRIPTION
Implements #35 
Some things to test:
- [x] Override with a primary node that supports debug_traceCall and a list of distinct secondary node.
   - App should run fine with no difference in app behavior.
- [x] Override with a primary node that doesn't support debug_traceCall.
   - Saving should warn you, and simulations should not be able to run (with a dialog to revert back to default configuration)
- [x] Override with a primary node that supports debug_traceCall but doesn't support state overrides
   - Saving should warn you, and simulations should not be able to run (with a dialog to revert back to default configuration)
- [x] Override with a primary node that supports debug_traceCall but an empty secondary nodes.
   - Saving should warn you, you could run simulations (a warn dialog should appear to state the risks and an option to revert back to default configuration)
   - State verification step in simulation loading screen should show with warn colors
   - Trust minimized cards should not be shown in loading/simulation screens in that case
- [x] Override with an invalid primary node (either broken url, or mismatching node)
   - Saving should be blocked until primary node is replaced
- [x] Override with a 1+ invalid secondary nodes (either broken url, or mismatching node)
   - Saving is not blocked, all broken/mismatching nodes are discarded from the configuration (the user is notified)
- [x] Override with a duplicated secondary nodes (either duplicated between each other or with the primary node)
   - Saving is not blocked, user is given a warning that x duplicate nodes are found and will be discarded from the configuration if he wishes to continue saving.
- [x] Custom configurations are persisted through app restarts.