### PR TITLE
fix: handle REVM gas limit and error cases in simulation

### DIFF
--- a/lib/shared/models/simulation/evm_tracer.dart
+++ b/lib/shared/models/simulation/evm_tracer.dart
@@ -51,6 +51,7 @@ class EVMTracer {
     }
     var block = prestate.$1;
     var baseFeePerGas = Utilities.decodeBigInt(block["baseFeePerGas"])!.scale(1.25);
+    var blockGasLimit = Utilities.decodeBigInt(block["gasLimit"])!;
     var blockRaw = jsonEncode(prestate.$1);
     var traceRaw = jsonEncode(prestate.$2);
     var chainId = await provider.getChainId();
@@ -60,7 +61,7 @@ class EVMTracer {
       fromNonce: BigInt.from(0),
       to: to,
       data: data,
-      gasLimit: BigInt.from(30_000_000),
+      gasLimit: blockGasLimit,
       gasPrice: baseFeePerGas,
       gasPriorityFee: baseFeePerGas,
       latestBlockEnv: blockRaw,

--- a/lib/shared/models/simulation/state_verifier/evm_state_verifier.dart
+++ b/lib/shared/models/simulation/state_verifier/evm_state_verifier.dart
@@ -49,65 +49,69 @@ class EVMStateVerifier {
     required BigInt blockNumber,
     String? stateRoot
   }) async {
-    // Get proof from proof node
-    final proof = await proofNodeClient.makeRPCCall('eth_getProof', [
-      account.with0x,
-      storageKeys.toList(),
-      blockNumber.toHex(),
-    ]);
+    try {
+      // Get proof from proof node
+      final proof = await proofNodeClient.makeRPCCall('eth_getProof', [
+        account.with0x,
+        storageKeys.toList(),
+        blockNumber.toHex(),
+      ]);
 
-    // Fetch state roots from all verification nodes and verify state root consensus (or use provided state root if available)
-    if (stateRoot == null){
-      var (_succcess, _stateRoot, _error) = await getConsensusStateRoot(blockNumber: blockNumber);
-      if (!_succcess){
-        return (false, _error);
+      // Fetch state roots from all verification nodes and verify state root consensus (or use provided state root if available)
+      if (stateRoot == null){
+        var (_succcess, _stateRoot, _error) = await getConsensusStateRoot(blockNumber: blockNumber);
+        if (!_succcess){
+          return (false, _error);
+        }
+        stateRoot = _stateRoot;
       }
-      stateRoot = _stateRoot;
-    }
 
-    // Verify account proof
-    final accountValid = ProofVerifier.verifyAccountProof(
-      stateRoot: stateRoot,
-      address: account.with0x,
-      proof: proof,
-    );
-
-    if (!accountValid) {
-      return (false, "Account proof for ${account.with0x} is INVALID");
-    }
-
-    // Verify storage proofs
-    final storageProofs = proof['storageProof'] as List;
-    for (var i = 0; i < storageProofs.length; i++) {
-      final storageProof = storageProofs[i] as Map<String, dynamic>;
-      final key = storageProof['key'] as String;
-      final value = storageProof['value'] as String;
-      final proofArray = (storageProof['proof'] as List).cast<String>();
-      // Verify the storage proof
-      final storageValid = ProofVerifier.verifyStorageProof(
-        storageHash: proof['storageHash'],
-        storageKey: key,
-        storageValue: value,
-        storageProof: proofArray,
+      // Verify account proof
+      final accountValid = ProofVerifier.verifyAccountProof(
+        stateRoot: stateRoot,
+        address: account.with0x,
+        proof: proof,
       );
 
-      if (storageValid) {
-        // Check if value matches expected
-        final expectedValue = expectedStorageValues[key];
-        if (expectedValue != null) {
-          // Normalize both values by removing leading zeros for comparison
-          String normalizedValue = _normalizeHex(value);
-          String normalizedExpected = _normalizeHex(expectedValue);
-
-          if (normalizedValue != normalizedExpected) {
-            return (false, "Expected values mismatch, expected $expectedValue, got $value (${account.with0x})");
-          }
-        }
-      } else {
-        return (false, "Storage proof is INVALID for key $key (${account.with0x})");
+      if (!accountValid) {
+        return (false, "Account proof for ${account.with0x} is INVALID");
       }
+
+      // Verify storage proofs
+      final storageProofs = proof['storageProof'] as List;
+      for (var i = 0; i < storageProofs.length; i++) {
+        final storageProof = storageProofs[i] as Map<String, dynamic>;
+        final key = storageProof['key'] as String;
+        final value = storageProof['value'] as String;
+        final proofArray = (storageProof['proof'] as List).cast<String>();
+        // Verify the storage proof
+        final storageValid = ProofVerifier.verifyStorageProof(
+          storageHash: proof['storageHash'],
+          storageKey: key,
+          storageValue: value,
+          storageProof: proofArray,
+        );
+
+        if (storageValid) {
+          // Check if value matches expected
+          final expectedValue = expectedStorageValues[key];
+          if (expectedValue != null) {
+            // Normalize both values by removing leading zeros for comparison
+            String normalizedValue = _normalizeHex(value);
+            String normalizedExpected = _normalizeHex(expectedValue);
+
+            if (normalizedValue != normalizedExpected) {
+              return (false, "Expected values mismatch, expected $expectedValue, got $value (${account.with0x})");
+            }
+          }
+        } else {
+          return (false, "Storage proof is INVALID for key $key (${account.with0x})");
+        }
+      }
+      return (true, '');
+    } catch (e) {
+      return (false, "eth_getProof RPC call failed: $e");
     }
-    return (true, '');
   }
 }
 

--- a/lib/shared/models/simulation/trace_decoder.dart
+++ b/lib/shared/models/simulation/trace_decoder.dart
@@ -308,6 +308,20 @@ class TraceDecoder {
   }
 
   SimulationResult decode(String account, SafeTransaction transaction, Network network, Map<String, dynamic> trace){
+    // Handle REVM-level errors (e.g. gas limit exceeded, validation failures)
+    if (trace["error"] == true) {
+      return SimulationResult(
+        success: false,
+        revertReason: trace["message"] as String? ?? "REVM execution error",
+        dangerous: (false, null, ""),
+        transfers: [],
+        allowances: [],
+        nftTransfers: [],
+        nftAllowances: [],
+        safeSettingsChanges: [],
+        warningTransactions: [],
+      );
+    }
     var executionResult = trace["executionResult"] as Map<String, dynamic>;
     if (!executionResult.containsKey("Success")) {
       String revertReason = executionResult["Revert"]["output"];


### PR DESCRIPTION
Simulations were failing on Gnosis chain with two issues:

1. **Gas limit exceeded**: REVM was using a hardcoded 30M gas limit, but Gnosis blocks have ~17M gas limit, causing "gas limit exceeded" errors
2. **Null pointer crash**: When REVM failed, it returned `{"error": true, "message": "..."}` instead of the expected `{"executionResult": {...}}`, causing the trace decoder to crash when
accessing `executionResult`

so i did the following:

1. Dynamic gas limit (evm_tracer.dart)
I took the actual block gas limit from the fetched block data and pass it to REVM, instead of hardcoding 30M.

2. REVM error handling (trace_decoder.dart)
I checked for `trace["error"] == true` before accessing `trace["executionResult"]` and returned a proper error SimulationResult.

3. eth_getProof error handling (evm_state_verifier.dart)
Wrap the eth_getProof RPC call in try-catch to handle node failures or pruned data gracefully with clear error messages.

Tested:

- Gnosis transaction simulation now succeeds (previously failed with gas limit error)
- Error cases return proper error messages instead of crashing
- Other networks (Ethereum, OP mainnet) continue working as befor