### PR TITLE
Offline graceful degradation for verify flow

### DIFF
--- a/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
+++ b/lib/features/verify_safe_transaction/hashes_verification/safe_hashes_verify_screen.dart
@@ -6,6 +6,8 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
 import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+import 'package:safe_opensig/shared/widgets/missing_latest_nonce_banner.dart';
+import 'package:safe_opensig/shared/widgets/offline_capability_note.dart';
 
 class SafeHashesVerifyScreen extends StatefulWidget {
   final SafeAccount safeAccount;
@@ -31,7 +33,16 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Verify Transaction')),
+      appBar: AppBar(
+        title: const Text('Verify Transaction'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.airplanemode_active),
+            tooltip: 'Can work offline',
+            onPressed: () => showOfflineCapabilitySheet(context),
+          ),
+        ],
+      ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return SingleChildScrollView(
@@ -41,6 +52,8 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
+                    if (missingLatestNonceMessage(widget.safeTransaction) case final msg?)
+                      MissingLatestNonceBanner(message: msg),
                     if (widget.safeTransaction.nonceIsEditable)
                       _NonceControl(
                         initialValue: widget.safeTransaction.nonce,
@@ -71,12 +84,14 @@ class _SafeHashesVerifyScreenState extends State<SafeHashesVerifyScreen> {
                         ),
                         SizedBox(width: 4),
                         ElevatedButton(
-                          onPressed: () {
-                            GoRouter.of(context).push(
-                              "/verify-transaction/ledger",
-                              extra: (widget.safeAccount, widget.safeTransaction)
-                            );
-                          },
+                          onPressed: widget.safeTransaction.nonce == null
+                              ? null
+                              : () {
+                                  GoRouter.of(context).push(
+                                    "/verify-transaction/ledger",
+                                    extra: (widget.safeAccount, widget.safeTransaction)
+                                  );
+                                },
                           child: const Text('Verify Ledger Screens'),
                         ),
                       ],
@@ -228,10 +243,16 @@ class _TransactionHashesCardState extends State<_TransactionHashesCard> {
 
   @override
   Widget build(BuildContext context) {
-    widget.safeTransaction.calculateHashes(widget.safeAccount).then((result) {
-      if (!mounted) return;
-      setState(() => _hashes = result);
-    });
+    final hasNonce = widget.safeTransaction.nonce != null;
+    if (hasNonce) {
+      widget.safeTransaction.calculateHashes(widget.safeAccount).then((result) {
+        if (!mounted) return;
+        setState(() => _hashes = result);
+      });
+    } else {
+      // Reset so a prior calculation isn't shown while the user is editing
+      _hashes = null;
+    }
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       child: Padding(
@@ -244,7 +265,14 @@ class _TransactionHashesCardState extends State<_TransactionHashesCard> {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 12),
-            if (_hashes == null)
+            if (!hasNonce)
+              Text(
+                'Set a nonce above to calculate hashes.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              )
+            else if (_hashes == null)
               const Center(child: CircularProgressIndicator())
             else if (!_hashes!.$1)
               const Text('Failed to calculate hashes')
@@ -566,14 +594,17 @@ class _NonceControl extends StatefulWidget {
 }
 
 class _NonceControlState extends State<_NonceControl> {
-  late BigInt _nonce;
+  /// Null until the user commits a value. Offline + calldata can arrive here
+  /// without a starting nonce; we show a placeholder until the first tap so
+  /// the display doesn't contradict the "set it manually" banner.
+  BigInt? _nonce;
   Timer? _incrementTimer;
   Timer? _decrementTimer;
 
   @override
   void initState() {
     super.initState();
-    _nonce = widget.initialValue ?? BigInt.zero;
+    _nonce = widget.initialValue;
   }
 
   @override
@@ -586,7 +617,7 @@ class _NonceControlState extends State<_NonceControl> {
   void _startIncrementing() {
     _incrementTimer = Timer.periodic(const Duration(milliseconds: 150), (timer) {
       setState(() {
-        _nonce = _nonce + BigInt.one;
+        _nonce = (_nonce ?? BigInt.zero) + BigInt.one;
       });
     });
   }
@@ -594,9 +625,8 @@ class _NonceControlState extends State<_NonceControl> {
   void _startDecrementing() {
     _decrementTimer = Timer.periodic(const Duration(milliseconds: 150), (timer) {
       setState(() {
-        if (_nonce > BigInt.zero) {
-          _nonce = _nonce - BigInt.one;
-        }
+        final current = _nonce ?? BigInt.zero;
+        _nonce = current > BigInt.zero ? current - BigInt.one : BigInt.zero;
       });
     });
   }
@@ -604,23 +634,23 @@ class _NonceControlState extends State<_NonceControl> {
   void _stopChanging() {
     _incrementTimer?.cancel();
     _decrementTimer?.cancel();
-    widget.onChange(_nonce);
+    final value = _nonce;
+    if (value != null) widget.onChange(value);
   }
 
   void _incrementNonce() {
     setState(() {
-      _nonce = _nonce + BigInt.one;
+      _nonce = (_nonce ?? BigInt.zero) + BigInt.one;
     });
-    widget.onChange(_nonce);
+    widget.onChange(_nonce!);
   }
 
   void _decrementNonce() {
     setState(() {
-      if (_nonce > BigInt.zero) {
-        _nonce = _nonce - BigInt.one;
-      }
+      final current = _nonce ?? BigInt.zero;
+      _nonce = current > BigInt.zero ? current - BigInt.one : BigInt.zero;
     });
-    widget.onChange(_nonce);
+    widget.onChange(_nonce!);
   }
 
   @override
@@ -663,9 +693,9 @@ class _NonceControlState extends State<_NonceControl> {
                     fit: BoxFit.scaleDown,
                     child: Text.rich(
                       TextSpan(
-                        text: '$_nonce',
+                        text: _nonce == null ? '—' : '$_nonce',
                         children: [
-                          if (widget.latestNonce == _nonce)
+                          if (_nonce != null && widget.latestNonce == _nonce)
                             TextSpan(
                               text: "\nlatest",
                               style: TextStyle(

--- a/lib/features/verify_safe_transaction/ledger_verification/safe_ledger_verify_screen.dart
+++ b/lib/features/verify_safe_transaction/ledger_verification/safe_ledger_verify_screen.dart
@@ -7,6 +7,7 @@ import 'package:safe_opensig/shared/models/hw_wallets/hw_content_generator.dart'
 import 'package:safe_opensig/shared/models/hw_wallets/ledger/ledger_nano_s_plus.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
 import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+import 'package:safe_opensig/shared/widgets/offline_capability_note.dart';
 import 'package:version/version.dart';
 
 class SafeLedgerVerifyScreen extends StatefulWidget {
@@ -37,7 +38,14 @@ class _SafeLedgerVerifyScreenState extends State<SafeLedgerVerifyScreen> {
           icon: const Icon(Icons.arrow_back_outlined),
           onPressed: () => setState(() {previousPageIndex=1;currentPageIndex = 0;}),
         ),
-        title: const Text('Hardware Verification')
+        title: const Text('Hardware Verification'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.airplanemode_active),
+            tooltip: 'Can work offline',
+            onPressed: () => showOfflineCapabilitySheet(context),
+          ),
+        ],
       ),
       body: PageTransitionSwitcher(
         duration: const Duration(milliseconds: 500),
@@ -61,8 +69,38 @@ class _SafeLedgerVerifyScreenState extends State<SafeLedgerVerifyScreen> {
             widget.safeTransaction,
           ),
           builder: (BuildContext context, AsyncSnapshot snapshot) {
-            if (snapshot.connectionState != ConnectionState.done){
-              return CircularProgressIndicator();
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (snapshot.hasError || snapshot.data == null) {
+              return Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error_outline, size: 48),
+                    const SizedBox(height: 16),
+                    const Text(
+                      "Couldn't build the Ledger preview.",
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${snapshot.error ?? "Unknown error"}',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 24),
+                    OutlinedButton(
+                      onPressed: () => setState(() {
+                        previousPageIndex = 1;
+                        currentPageIndex = 0;
+                      }),
+                      child: const Text('Back'),
+                    ),
+                  ],
+                ),
+              );
             }
             return LedgerContentVerificationScreen(
               pages: snapshot.data,
@@ -74,18 +112,32 @@ class _SafeLedgerVerifyScreenState extends State<SafeLedgerVerifyScreen> {
   }
 
   Widget _hwSelectionPage(){
-    return Padding(
-      padding: EdgeInsets.all(16.0),
-      child: _HardwareWalletSelectionPage(
-        onProceed: (){
-          setState(() {
-            currentPageIndex = 1;
-          });
-        },
-        onSkip: (){
-          GoRouter.of(context).go("/accounts");
-        },
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minWidth: constraints.maxWidth,
+              minHeight: constraints.maxHeight,
+            ),
+            child: IntrinsicHeight(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: _HardwareWalletSelectionPage(
+                  onProceed: (){
+                    setState(() {
+                      currentPageIndex = 1;
+                    });
+                  },
+                  onSkip: (){
+                    GoRouter.of(context).go("/accounts");
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -94,7 +146,10 @@ class _SafeLedgerVerifyScreenState extends State<SafeLedgerVerifyScreen> {
 class _HardwareWalletSelectionPage extends StatelessWidget {
   final VoidCallback onProceed;
   final VoidCallback onSkip;
-  const _HardwareWalletSelectionPage({required this.onProceed, required this.onSkip});
+  const _HardwareWalletSelectionPage({
+    required this.onProceed,
+    required this.onSkip,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
+++ b/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
@@ -79,12 +79,17 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
 
   void _onSubmit() async {
     var cancelLoad = BotToast.showLoading();
-    final (success, error) = await safeTransaction!.ensureNonce(widget.safeAccount);
+    await safeTransaction!.ensureNonce(widget.safeAccount);
     cancelLoad();
     if (!mounted) return;
 
-    if (!success) {
-      BotToast.showText(text: error);
+    // If we still have no nonce (calldata path + offline), skip simulation
+    // and let the user set it manually on the hashes screen.
+    if (safeTransaction!.nonce == null) {
+      GoRouter.of(context).push(
+        "/verify-transaction/hashes",
+        extra: (widget.safeAccount, safeTransaction!),
+      );
       return;
     }
 

--- a/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
+++ b/lib/features/verify_safe_transaction/simulation/simulation_loading_screen.dart
@@ -172,6 +172,16 @@ class _SimulationLoadingScreenState extends State<SimulationLoadingScreen> {
                 const SizedBox(height: 32),
                 ElevatedButton(
                   onPressed: () {
+                    GoRouter.of(context).pushReplacement(
+                      "/verify-transaction/hashes",
+                      extra: (widget.safeAccount, widget.transaction),
+                    );
+                  },
+                  child: const Text('Continue to Hashes'),
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () {
                     GoRouter.of(context).pop();
                   },
                   child: const Text('Go Back'),

--- a/lib/shared/models/safe_account_model.dart
+++ b/lib/shared/models/safe_account_model.dart
@@ -69,7 +69,7 @@ class SafeAccount with EquatableMixin {
       var response = await network.provider.callRaw(
           contract: EthereumAddress.fromHex(address),
           data: hexToBytes("0xaffed0e0")
-      );
+      ).timeout(const Duration(seconds: 5));
       return BigInt.parse(response);
     } catch (e) {
       return null;

--- a/lib/shared/models/safe_transaction_model.dart
+++ b/lib/shared/models/safe_transaction_model.dart
@@ -62,17 +62,21 @@ class SafeTransaction {
   }
 
   /// Ensures nonce is set by fetching it from the account if not already set
-  /// Also fetches and stores the latest nonce from the account for simulation
+  /// Also fetches and stores the latest nonce from the account for simulation.
+  /// Best-effort: never returns false. On fetch failure we leave latestNonce
+  /// null, and if nonce was unset we just mark it editable so the verify
+  /// screen prompts the user to enter one manually.
   Future<(bool, String)> ensureNonce(SafeAccount account) async {
     final fetchedNonce = await account.getNonce();
-    if (fetchedNonce == null) {
-      return (false, 'Failed to fetch nonce');
+    if (fetchedNonce != null) {
+      latestNonce = fetchedNonce;
+      if (nonce == null) {
+        nonce = fetchedNonce;
+        nonceIsEditable = true;
+      }
+      return (true, '');
     }
-    latestNonce = fetchedNonce;
-    // If nonce is not set (CallData input), use the latest nonce and mark it
-    // as editable so the verify screen lets the user adjust it.
     if (nonce == null) {
-      nonce = fetchedNonce;
       nonceIsEditable = true;
     }
     return (true, '');
@@ -149,7 +153,12 @@ class SafeTransaction {
       return (false, error);
     }
     // Use latestNonce for simulation, nonce for hash verification
-    final nonceToUse = useLatestNonce ? latestNonce! : nonce!;
+    final BigInt? nonceToUse = useLatestNonce ? latestNonce : nonce;
+    if (nonceToUse == null) {
+      return (false, useLatestNonce
+          ? 'Latest nonce unavailable'
+          : 'Nonce is not set');
+    }
     Uint8List message = encodeAbi(
         [
           "bytes32",

--- a/lib/shared/widgets/missing_latest_nonce_banner.dart
+++ b/lib/shared/widgets/missing_latest_nonce_banner.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+
+/// Inline info banner used whenever the latest onchain nonce couldn't be
+/// fetched, so the user is aware they need to confirm the nonce themselves.
+class MissingLatestNonceBanner extends StatelessWidget {
+  final String message;
+  const MissingLatestNonceBanner({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: theme.colorScheme.outline.withValues(alpha: 0.2),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 18,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.bodySmall?.copyWith(height: 1.4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Returns the banner copy to display when we couldn't fetch the latest nonce,
+/// or null when no banner is needed (latestNonce is known).
+String? missingLatestNonceMessage(SafeTransaction transaction) {
+  if (transaction.latestNonce != null) return null;
+  if (transaction.nonceIsEditable) {
+    if (transaction.nonce == null) {
+      return "Couldn't reach the network to fetch the latest nonce. Set it manually and make "
+          'sure it matches the latest onchain nonce.';
+    }
+    return "Couldn't reach the network to fetch the latest nonce. Make sure the value above "
+        'matches the latest onchain nonce.';
+  }
+  return "Couldn't reach the network to fetch the latest nonce. Confirm this matches the "
+      'latest onchain nonce before signing.';
+}

--- a/lib/shared/widgets/offline_capability_note.dart
+++ b/lib/shared/widgets/offline_capability_note.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+void showOfflineCapabilitySheet(BuildContext context) {
+  showModalBottomSheet(
+    context: context,
+    backgroundColor: Theme.of(context).colorScheme.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (_) => const _OfflineCapabilitySheet(),
+  );
+}
+
+class _OfflineCapabilitySheet extends StatelessWidget {
+  const _OfflineCapabilitySheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dim = theme.colorScheme.onSurface.withValues(alpha: 0.5);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.airplanemode_active, size: 18, color: dim),
+              const SizedBox(width: 8),
+              Text(
+                'Can work air-gapped',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Hash calculation and Ledger review run on device. When offline, the latest onchain nonce can\'t be verified, a banner will prompt you to confirm it manually.',
+            style: theme.textTheme.bodySmall?.copyWith(color: dim, height: 1.5),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/safe_transaction_ensure_nonce_test.dart
+++ b/test/safe_transaction_ensure_nonce_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:safe_opensig/shared/models/safe_account_model.dart';
+import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+
+// ignore: must_be_immutable
+class _FakeSafeAccount extends SafeAccount {
+  final BigInt? Function() _getNonce;
+
+  _FakeSafeAccount({required BigInt? Function() getNonce})
+      : _getNonce = getNonce,
+        super(
+          id: 'test',
+          name: 'Test',
+          address: '0x0000000000000000000000000000000000000001',
+          chainId: 1,
+          version: '1.4.1',
+        );
+
+  @override
+  Future<BigInt?> getNonce() async => _getNonce();
+}
+
+SafeTransaction _tx({BigInt? nonce}) => SafeTransaction(
+      to: '0x0000000000000000000000000000000000000002',
+      value: BigInt.zero,
+      data: '0x',
+      operation: 0,
+      safeTxGas: BigInt.zero,
+      baseGas: BigInt.zero,
+      gasPrice: BigInt.zero,
+      gasToken: '0x0000000000000000000000000000000000000000',
+      refundReceiver: '0x0000000000000000000000000000000000000000',
+      nonce: nonce,
+    );
+
+void main() {
+  group('SafeTransaction.ensureNonce', () {
+    test('nonce set, fetch succeeds: latestNonce populated, success', () async {
+      final tx = _tx(nonce: BigInt.from(7));
+      final account = _FakeSafeAccount(getNonce: () => BigInt.from(10));
+
+      final (ok, err) = await tx.ensureNonce(account);
+
+      expect(ok, isTrue);
+      expect(err, isEmpty);
+      expect(tx.nonce, BigInt.from(7));
+      expect(tx.latestNonce, BigInt.from(10));
+      expect(tx.nonceIsEditable, isFalse);
+    });
+
+    test('nonce set, fetch fails: success with null latestNonce', () async {
+      final tx = _tx(nonce: BigInt.from(7));
+      final account = _FakeSafeAccount(getNonce: () => null);
+
+      final (ok, err) = await tx.ensureNonce(account);
+
+      expect(ok, isTrue);
+      expect(err, isEmpty);
+      expect(tx.nonce, BigInt.from(7));
+      expect(tx.latestNonce, isNull);
+      expect(tx.nonceIsEditable, isFalse);
+    });
+
+    test('nonce null, fetch succeeds: both adopted, editable', () async {
+      final tx = _tx(nonce: null);
+      final account = _FakeSafeAccount(getNonce: () => BigInt.from(10));
+
+      final (ok, err) = await tx.ensureNonce(account);
+
+      expect(ok, isTrue);
+      expect(err, isEmpty);
+      expect(tx.nonce, BigInt.from(10));
+      expect(tx.latestNonce, BigInt.from(10));
+      expect(tx.nonceIsEditable, isTrue);
+    });
+
+    test('nonce null, fetch fails: success, nonce stays null, editable', () async {
+      final tx = _tx(nonce: null);
+      final account = _FakeSafeAccount(getNonce: () => null);
+
+      final (ok, err) = await tx.ensureNonce(account);
+
+      expect(ok, isTrue);
+      expect(err, isEmpty);
+      expect(tx.nonce, isNull);
+      expect(tx.latestNonce, isNull);
+      expect(tx.nonceIsEditable, isTrue);
+    });
+  });
+
+  group('SafeTransaction.getMessageHash', () {
+    test('returns error when useLatestNonce true and latestNonce null',
+        () async {
+      final tx = _tx(nonce: BigInt.from(7));
+      final account = _FakeSafeAccount(getNonce: () => null);
+
+      final (ok, msg) = await tx.getMessageHash(account, useLatestNonce: true);
+
+      expect(ok, isFalse);
+      expect(msg.toLowerCase(), contains('nonce'));
+    });
+
+    test('returns error when nonce null', () async {
+      final tx = _tx(nonce: null);
+      final account = _FakeSafeAccount(getNonce: () => null);
+
+      final (ok, msg) = await tx.getMessageHash(account);
+
+      expect(ok, isFalse);
+      expect(msg.toLowerCase(), contains('nonce'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #37.

- `ensureNonce` is best-effort so offline no longer blocks the flow
- Simulation error screen offers "Continue to Hashes" instead of dead-ending
- Hashes screen shows a banner when the latest onchain nonce couldn't be fetched, so signers confirm it manually
- "Can work air-gapped" note stays truthful