### PR TITLE
fix: open block explorer link from address detail sheet

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,5 +47,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/shared/widgets/address_detail_sheet.dart
+++ b/lib/shared/widgets/address_detail_sheet.dart
@@ -44,15 +44,13 @@ class AddressDetailSheet extends StatelessWidget {
   }
 
   Future<void> _handleExplorer(BuildContext context, String url) async {
+    final messenger = ScaffoldMessenger.of(context);
+    Navigator.of(context).pop();
     try {
       final uri = Uri.parse(url);
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        throw Exception('Cannot launch URL');
-      }
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('Failed to open block explorer'),
           duration: Duration(seconds: 2),

--- a/lib/shared/widgets/address_detail_sheet.dart
+++ b/lib/shared/widgets/address_detail_sheet.dart
@@ -48,7 +48,16 @@ class AddressDetailSheet extends StatelessWidget {
     Navigator.of(context).pop();
     try {
       final uri = Uri.parse(url);
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      final launched =
+          await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!launched) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('Failed to open block explorer'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
     } catch (e) {
       messenger.showSnackBar(
         const SnackBar(


### PR DESCRIPTION
Tapping "View on Block Explorer" in the address detail sheet did nothing on Android 11+. Two causes:

1. `AndroidManifest.xml` didn't declare a `<queries>` intent for the `https` scheme, so `canLaunchUrl` returned false on Android 11+ even though the OS could open the URL.
2. The handler gated `launchUrl` behind `canLaunchUrl`, which is unreliable across platforms, and left the bottom sheet open so the error snackbar was hidden underneath.

The same code path is used by every `AddressWidget` in the app, so this affected allowances, transfers, account list, and Safe API cards — not just the allowance page where it was reported.

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block explorer link behavior from address details: sheet now closes immediately, links open more reliably, and failures show a clearer snackbar message.
  * Enhanced Android intent declarations to better handle https VIEW links, improving URL-handling compatibility on Android devices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/safe-opensig/pull/83)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/safe-opensig/pull/83)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->