### PR TITLE
fix: simulation failed on Safe v1.3.0 owner/module/guard changes

### DIFF
--- a/lib/shared/models/simulation/trace_decoder.dart
+++ b/lib/shared/models/simulation/trace_decoder.dart
@@ -102,6 +102,15 @@ class TraceDecoder {
     return true;
   }
 
+  // Safe owner/module/guard events carry a single address parameter that is
+  // non-indexed in Safe <=1.3.0 (the address lives in `data`) and indexed in
+  // Safe >=1.4.0 (the address lives in topics[1]). The event signature hash is
+  // identical for both, so read from whichever location is actually present.
+  EthereumAddress _decodeEventAddress(List<String> topics, Map<String, dynamic> log){
+    var encoded = topics.length > 1 ? topics[1] : log["data"].toString();
+    return decodeAbi(["address"], hexToBytes(encoded))[0] as EthereumAddress;
+  }
+
   dynamic processLog(String account, Network network, Map<String, dynamic> log){
     account = account.toLowerCase();
     var topics = (log["topics"] as List<dynamic>).cast<String>();
@@ -209,13 +218,13 @@ class TraceDecoder {
           network: network,
         );
       }else if (eventName == "safe-owner-addition"){
-        var addedOwner = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var addedOwner = _decodeEventAddress(topics, log);
         return SafeSettingChange(
           type: SafeSettingChangeType.OWNER_ADDITION,
           data: [addedOwner]
         );
       }else if (eventName == "safe-owner-revocation"){
-        var revokedOwner = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var revokedOwner = _decodeEventAddress(topics, log);
         return SafeSettingChange(
           type: SafeSettingChangeType.OWNER_REVOCATION,
           data: [revokedOwner]
@@ -227,25 +236,25 @@ class TraceDecoder {
           data: [newThreshold]
         );
       }else if (eventName == "safe-module-enable"){
-        var newModule = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var newModule = _decodeEventAddress(topics, log);
         return WarningTransaction(
           type: WarningTransactionType.MODULE_ADDITION,
           data: [newModule]
         );
       }else if (eventName == "safe-module-disable"){
-        var disabledModule = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var disabledModule = _decodeEventAddress(topics, log);
         return WarningTransaction(
           type: WarningTransactionType.MODULE_REVOCATION,
           data: [disabledModule]
         );
       }else if (eventName == "safe-module-guard-change"){
-        var newModuleGuard = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var newModuleGuard = _decodeEventAddress(topics, log);
         return WarningTransaction(
           type: WarningTransactionType.MODULE_GUARD_CHANGE,
           data: [newModuleGuard]
         );
       }else if (eventName == "safe-guard-change"){
-        var newGuard = decodeAbi(["address"], hexToBytes(topics[1]))[0] as EthereumAddress;
+        var newGuard = _decodeEventAddress(topics, log);
         return WarningTransaction(
           type: WarningTransactionType.GUARD_CHANGE,
           data: [newGuard]

--- a/test/trace_decoder_owner_event_test.dart
+++ b/test/trace_decoder_owner_event_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wallet/wallet.dart';
+import 'package:safe_opensig/shared/models/network_model.dart';
+import 'package:safe_opensig/shared/models/simulation/safe_setting_change.dart';
+import 'package:safe_opensig/shared/models/simulation/trace_decoder.dart';
+
+// Regression test for the "RangeError (length): Only valid value is 0: 1"
+// simulation failure on swapOwner transactions.
+//
+// Safe owner/module/guard events changed their parameter indexing between
+// versions: in Safe <=1.3.0 the address is a NON-indexed parameter (carried in
+// `data`, so `topics` only holds the event signature), while in Safe >=1.4.0 it
+// is indexed (carried in `topics[1]`). The decoder previously always read
+// `topics[1]`, which overran the topics list for <=1.3.0 events and threw.
+void main() {
+  // Owner events build a SafeSettingChange that never references the network,
+  // so a bare stub avoids loading RPC config from .env.
+  const network = Network(
+    name: 'Test',
+    chainPrefix: 'eth',
+    chainId: 1,
+    nativeCurrencySymbol: 'ETH',
+    providers: [],
+    explorers: [],
+  );
+  const account = '0x1111111111111111111111111111111111111111';
+  const owner = '0x00000000000000000000000000000000000000aa';
+  const ownerWord =
+      '0x00000000000000000000000000000000000000000000000000000000000000aa';
+  const removedOwnerSig =
+      '0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf';
+  const addedOwnerSig =
+      '0x9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26';
+
+  final decoder = TraceDecoder(accountSingleton: '0x0');
+  final expectedOwner = EthereumAddress.fromHex(owner);
+
+  group('TraceDecoder.processLog owner events', () {
+    test('Safe <=1.3.0 non-indexed RemovedOwner decodes from data', () {
+      final result = decoder.processLog(account, network, {
+        'address': account,
+        'topics': [removedOwnerSig], // only the signature, owner is non-indexed
+        'data': ownerWord,
+      }) as SafeSettingChange;
+
+      expect(result.type, SafeSettingChangeType.OWNER_REVOCATION);
+      expect(result.data.first, expectedOwner);
+    });
+
+    test('Safe >=1.4.0 indexed RemovedOwner decodes from topics[1]', () {
+      final result = decoder.processLog(account, network, {
+        'address': account,
+        'topics': [removedOwnerSig, ownerWord], // owner indexed
+        'data': '0x',
+      }) as SafeSettingChange;
+
+      expect(result.type, SafeSettingChangeType.OWNER_REVOCATION);
+      expect(result.data.first, expectedOwner);
+    });
+
+    test('Safe <=1.3.0 non-indexed AddedOwner decodes from data', () {
+      final result = decoder.processLog(account, network, {
+        'address': account,
+        'topics': [addedOwnerSig],
+        'data': ownerWord,
+      }) as SafeSettingChange;
+
+      expect(result.type, SafeSettingChangeType.OWNER_ADDITION);
+      expect(result.data.first, expectedOwner);
+    });
+  });
+}


### PR DESCRIPTION
Simulating a transaction that changes a Safe v1.3.0's owners, modules, or guard (e.g. swapOwner) failed with "RangeError (length)".

v1.3.0 emits these events with the address as a non-indexed parameter (in the log data), while v1.4.0+ indexes it (in the topics). The signature hash is the same for both, so the decoder recognized the event but always read it from the topics, which throws on a v1.3.0 log. It now reads the address from wherever it actually is.

Confirmed against a real v1.3.0 Safe swapOwner that was hitting this. Added a regression test covering both the non-indexed (≤1.3.0) and indexed (≥1.4.0) layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Safe owner event decoding to reliably handle both indexed and non-indexed parameter formats across different Safe versions.

* **Tests**
  * Added regression test suite for Safe owner event processing, covering Safe versions ≤1.3.0 and ≥1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->