### PR TITLE
fix: pad storage keys to 32 bytes before MPT verification

### DIFF
--- a/lib/shared/models/simulation/state_verifier/evm_state_verifier.dart
+++ b/lib/shared/models/simulation/state_verifier/evm_state_verifier.dart
@@ -50,6 +50,11 @@ class EVMStateVerifier {
     String? stateRoot
   }) async {
     try {
+      final normalizedExpectedStorageValues = {
+        for (final entry in expectedStorageValues.entries)
+          normalizeStorageKey(entry.key): entry.value,
+      };
+
       // Get proof from proof node
       dynamic proof;
       int retries = 0;
@@ -108,7 +113,8 @@ class EVMStateVerifier {
 
         if (storageValid) {
           // Check if value matches expected
-          final expectedValue = expectedStorageValues[key];
+          final expectedValue =
+              normalizedExpectedStorageValues[normalizeStorageKey(key)];
           if (expectedValue != null) {
             // Normalize both values by removing leading zeros for comparison
             String normalizedValue = _normalizeHex(value);
@@ -127,6 +133,25 @@ class EVMStateVerifier {
       return (false, "eth_getProof RPC call failed: $e");
     }
   }
+}
+
+String normalizeStorageKey(String hex) {
+  if (hex.startsWith('0x') || hex.startsWith('0X')) {
+    hex = hex.substring(2);
+  }
+  if (hex.isEmpty) {
+    hex = '0';
+  }
+  if (!RegExp(r'^[0-9a-fA-F]+$').hasMatch(hex)) {
+    throw FormatException('Storage key contains non-hex characters');
+  }
+  if (hex.length % 2 != 0) {
+    hex = '0$hex';
+  }
+  if (hex.length > 64) {
+    throw FormatException('Storage key exceeds 32 bytes');
+  }
+  return '0x${hex.toLowerCase().padLeft(64, '0')}';
 }
 
 String _normalizeHex(String hex) {

--- a/lib/shared/models/simulation/state_verifier/proof_verifier.dart
+++ b/lib/shared/models/simulation/state_verifier/proof_verifier.dart
@@ -409,6 +409,13 @@ class ProofVerifier {
   }) {
     final storageRootBytes = HexUtil.decode(storageHash);
     final keyBytes = HexUtil.decode(storageKey);
+
+    // eth_getProof can return keys in minimal form (e.g. "0x0" for slot 0)
+    // depending on the RPC node implementation (e.g. Nethermind), but the
+    // storage trie always uses full 32-byte padded keys. Pad before hashing.
+    final paddedKey = Uint8List(32);
+    paddedKey.setRange(32 - keyBytes.length, 32, keyBytes);
+
     final valueBytes = HexUtil.decode(storageValue);
 
     // Encode value in RLP if not empty
@@ -420,7 +427,7 @@ class ProofVerifier {
 
     return verifyProof(
       rootHash: storageRootBytes,
-      key: keyBytes,
+      key: paddedKey,
       proof: storageProof,
       expectedValue: expectedValue,
     );

--- a/test/shared/models/simulation/state_verifier/evm_state_verifier_test.dart
+++ b/test/shared/models/simulation/state_verifier/evm_state_verifier_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:safe_opensig/shared/models/simulation/state_verifier/evm_state_verifier.dart';
+
+void main() {
+  group('normalizeStorageKey', () {
+    test('normalizes minimal and padded slot zero to the same key', () {
+      const paddedSlotZero =
+          '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+      expect(normalizeStorageKey('0x0'), paddedSlotZero);
+      expect(normalizeStorageKey(paddedSlotZero), paddedSlotZero);
+    });
+
+    test('normalizes odd-length minimal keys', () {
+      expect(
+        normalizeStorageKey('0xabc'),
+        '0x0000000000000000000000000000000000000000000000000000000000000abc',
+      );
+    });
+
+    test('accepts uppercase hex prefix', () {
+      expect(
+        normalizeStorageKey('0XABC'),
+        '0x0000000000000000000000000000000000000000000000000000000000000abc',
+      );
+    });
+
+    test('rejects non-hex storage keys', () {
+      expect(() => normalizeStorageKey('0xzz'), throwsFormatException);
+      expect(() => normalizeStorageKey('slot-0'), throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
eth_getProof returns storage keys in minimal hex form on my nethermind rpc (e.g. "0x0" for slot 0), but Ethereum's storage trie uses full 32-byte padded keys. Without padding, keccak256 produces a different hash and the MPT walk goes down the wrong path, causing 'Path not found in branch node' errors on any storage slot with a minimal key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage proof verification by ensuring storage slot keys are normalized/padded to the required 32-byte format before verifying proofs.
  * Added consistent handling of minimal hex storage keys (including odd-length and `0x0`-style inputs) to prevent mismatches during expected value lookups.
* **Tests**
  * Added coverage for storage key normalization to confirm canonical formatting behavior across common input variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->