### PR TITLE
Feat/erc4527 qr scanner

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
 val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+    FileInputStream(keystorePropertiesFile).use { input ->
+        keystoreProperties.load(input)
+    }
 }
 
 android {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,8 +9,9 @@ plugins {
 }
 
 val keystorePropertiesFile = rootProject.file("key.properties")
-val keystoreProperties = Properties().apply {
-    load(FileInputStream(keystorePropertiesFile))
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -30,11 +31,13 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
+        if (keystorePropertiesFile.exists()) {
+            create("release") {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
         }
     }
 
@@ -52,7 +55,9 @@ android {
 
     buildTypes {
         release {
-            signingConfig = signingConfigs["release"]
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs["release"]
+            }
         }
     }
 }

--- a/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
+++ b/lib/features/verify_safe_transaction/safe_transaction_form_screen.dart
@@ -12,6 +12,7 @@ import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_ca
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_calldata_input.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_json_guide_sheet.dart';
 import 'package:safe_opensig/features/verify_safe_transaction/widgets/safe_tx_json_input.dart';
+import 'package:safe_opensig/shared/widgets/ur_qr_scanner_sheet.dart';
 import 'package:safe_opensig/core/storage/network_config_box.dart';
 import 'package:safe_opensig/shared/constants/analytics_events.dart';
 import 'package:safe_opensig/shared/models/safe_account_model.dart';
@@ -334,6 +335,29 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
     );
   }
 
+  /// Open the continuous ERC-4527 / BC-UR fountain-code QR scanner.
+  /// Reconstructs the signing payload from animated QR frames and feeds
+  /// it straight into the verification pipeline as a SafeTransaction.
+  void _openUrScanner() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      isDismissible: true,
+      shape: RoundedRectangleBorder(
+        borderRadius: ThemeConfig.borderRadiusLarge,
+      ),
+      builder: (_) => UrQrScannerSheet(
+        legacyJson: isLegacyJson,
+        onComplete: (safeTx) {
+          setState(() => safeTransaction = safeTx);
+          _onSubmit();
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -460,6 +484,21 @@ class _SafeTransactionFormScreenState extends State<SafeTransactionFormScreen> {
             onValidInput: (safeTx) {
               setState(() => safeTransaction = safeTx);
             },
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: _openUrScanner,
+              icon: const Icon(Icons.qr_code_scanner_rounded, size: 18),
+              label: const Text('Scan ERC-4527 QR'),
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                shape: RoundedRectangleBorder(
+                  borderRadius: ThemeConfig.borderRadiusSmall,
+                ),
+              ),
+            ),
           ),
           const SizedBox(height: 12),
           SizedBox(

--- a/lib/shared/utils/ur_payload_decoder.dart
+++ b/lib/shared/utils/ur_payload_decoder.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bc_ur/bc_ur.dart';
+import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+
+/// Decodes a reconstructed BC-UR eth-sign-request into a [SafeTransaction].
+///
+/// ERC-4527 defines eth-sign-request as a CBOR map with integer keys:
+///
+///   key 1: request-id   (uuid, optional)
+///   key 2: sign-data    (bytes)  ← the payload we want
+///   key 3: data-type    (tag 401 wrapping an int enum)
+///   key 4: chain-id     (int, default 1)
+///   key 5: derivation-path (tag 304, optional)
+///   key 6: address      (20-byte address, optional)
+///   key 7: origin       (text, optional)
+///
+/// For Safe signing, data-type is 2 (eth-typed-data) and sign-data is
+/// the EIP-712 typed-data JSON. Its `message` object contains the SafeTx
+/// fields that OpenSig already uses in [SafeTransaction.getMessageHash]:
+///
+///   SafeTx(address to, uint256 value, bytes data, uint8 operation,
+///           uint256 safeTxGas, uint256 baseGas, uint256 gasPrice,
+///           address gasToken, address refundReceiver, uint256 nonce)
+class UrPayloadDecoder {
+  UrPayloadDecoder._();
+
+  /// ERC-4527 eth-sign-request CBOR field indices.
+  static const _keyRequestId = 1;
+  static const _keySignData = 2;
+  static const _keyDataType = 3;
+  static const _keyChainId = 4;
+  static const _keyDerivationPath = 5;
+  static const _keyAddress = 6;
+  static const _keyOrigin = 7;
+
+  /// data-type enum values (ERC-4527).
+  static const _dataTypeTransactionData = 1; // eth-transaction-data
+  static const _dataTypeTypedData = 2; // eth-typed-data (EIP-712)
+  static const _dataTypeRawBytes = 3; // eth-raw-bytes (EIP-191)
+  static const _dataTypeTypedTransaction = 4; // eth-typed-transaction
+
+  /// Decode a reconstructed [BCUR] into a [SafeTransaction].
+  ///
+  /// [legacyJson] should match the Safe account version (< 1.0.0 uses
+  /// `dataGas` instead of `baseGas`).
+  ///
+  /// Throws [FormatException] if the UR is not an eth-sign-request, the
+  /// data-type is not eth-typed-data, or the sign-data is not a valid
+  /// EIP-712 SafeTx payload.
+  static SafeTransaction decode(BCUR ur, {required bool legacyJson}) {
+    if (ur.type != 'eth-sign-request') {
+      throw FormatException(
+        'Expected UR type "eth-sign-request", got "${ur.type}".',
+      );
+    }
+
+    final decoded = ur.decodeData();
+    if (decoded is! Map) {
+      throw FormatException(
+        'Expected eth-sign-request CBOR map, got ${decoded.runtimeType}.',
+      );
+    }
+
+    // Extract sign-data from CBOR key 2 per the ERC-4527 CDDL.
+    final signData = decoded[_keySignData];
+    if (signData is! Uint8List) {
+      throw FormatException(
+        'eth-sign-request is missing sign-data (CBOR key $_keySignData).',
+      );
+    }
+
+    // Verify data-type if present. We only support eth-typed-data (2)
+    // for Safe signing. bc_ur decodes tagged values as {'tag': N, 'value': V}.
+    final dataType = decoded[_keyDataType];
+    if (dataType != null) {
+      final dataTypeValue = dataType is Map ? dataType['value'] : dataType;
+      if (dataTypeValue != _dataTypeTypedData) {
+        throw FormatException(
+          'Unsupported data-type $dataTypeValue. '
+          'OpenSig only supports eth-typed-data ($_dataTypeTypedData) '
+          'for Safe transaction verification.',
+        );
+      }
+    }
+
+    return _decodeEip712SignData(signData, legacyJson);
+  }
+
+  /// Parse the sign-data bytes as EIP-712 typed-data JSON and build a
+  /// [SafeTransaction] from the SafeTx `message` object.
+  static SafeTransaction _decodeEip712SignData(
+      Uint8List bytes, bool legacyJson) {
+    final String text;
+    try {
+      text = utf8.decode(bytes);
+    } catch (e) {
+      throw FormatException(
+        'sign-data is not valid UTF-8 (expected EIP-712 JSON): $e',
+      );
+    }
+
+    final Map<String, dynamic> typedData;
+    try {
+      final decoded = jsonDecode(text);
+      if (decoded is! Map<String, dynamic>) {
+        throw FormatException('Expected JSON object, got ${decoded.runtimeType}.');
+      }
+      typedData = decoded;
+    } catch (e) {
+      throw FormatException(
+        'sign-data is not valid EIP-712 JSON: $e',
+      );
+    }
+
+    // Unwrap the EIP-712 message. Full typed data has {types, domain, message};
+    // some wallets send just the message object directly.
+    final Map<String, dynamic> message;
+    if (typedData.containsKey('message') && typedData['message'] is Map) {
+      message = (typedData['message'] as Map).cast<String, dynamic>();
+    } else {
+      message = typedData;
+    }
+
+    // Validate required SafeTx fields are present.
+    const required = ['to', 'value', 'data', 'operation', 'safeTxGas',
+        'baseGas', 'gasPrice', 'gasToken', 'refundReceiver', 'nonce'];
+    final missing = required.where((f) => !message.containsKey(f)).toList();
+    if (missing.isNotEmpty) {
+      throw FormatException(
+        'EIP-712 message is missing SafeTx fields: $missing',
+      );
+    }
+
+    return _safeTxFromMessage(message, legacyJson);
+  }
+
+  /// Build a [SafeTransaction] from the EIP-712 message map, coercing
+  /// string-encoded values to the types [SafeTransaction.fromJson] expects.
+  static SafeTransaction _safeTxFromMessage(
+      Map<String, dynamic> msg, bool legacyJson) {
+    final bigIntFields = <String>{
+      'value', 'safeTxGas', 'gasPrice',
+    };
+    bigIntFields.add(legacyJson ? 'dataGas' : 'baseGas');
+
+    final cleaned = <String, dynamic>{};
+    for (final entry in msg.entries) {
+      var v = entry.value;
+      final key = entry.key;
+
+      if (v is String && bigIntFields.contains(key)) {
+        v = _parseBigInt(v);
+      }
+      if (key == 'nonce') {
+        if (v is String) v = _parseBigInt(v);
+        if (v is BigInt) v = v.toInt();
+      }
+      if (key == 'operation' && v is String) {
+        v = int.tryParse(v) ?? v;
+      }
+      cleaned[key] = v;
+    }
+    return SafeTransaction.fromJson(cleaned, legacyJson);
+  }
+
+  /// Parse a BigInt from a decimal or 0x-prefixed hex string.
+  static BigInt _parseBigInt(String s) {
+    if (s.startsWith('0x') || s.startsWith('0X')) {
+      return BigInt.parse(s.substring(2), radix: 16);
+    }
+    return BigInt.parse(s);
+  }
+}

--- a/lib/shared/utils/ur_payload_decoder.dart
+++ b/lib/shared/utils/ur_payload_decoder.dart
@@ -124,8 +124,9 @@ class UrPayloadDecoder {
     }
 
     // Validate required SafeTx fields are present.
-    const required = ['to', 'value', 'data', 'operation', 'safeTxGas',
-        'baseGas', 'gasPrice', 'gasToken', 'refundReceiver', 'nonce'];
+    final required = ['to', 'value', 'data', 'operation', 'safeTxGas',
+        legacyJson ? 'dataGas' : 'baseGas',
+        'gasPrice', 'gasToken', 'refundReceiver', 'nonce'];
     final missing = required.where((f) => !message.containsKey(f)).toList();
     if (missing.isNotEmpty) {
       throw FormatException(

--- a/lib/shared/widgets/ur_qr_scanner_sheet.dart
+++ b/lib/shared/widgets/ur_qr_scanner_sheet.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:bc_ur/bc_ur.dart';
+import 'package:safe_opensig/shared/models/safe_transaction_model.dart';
+import 'package:safe_opensig/shared/utils/ur_payload_decoder.dart';
+
+/// A continuous QR scanner that reconstructs an ERC-4527 / BC-UR
+/// fountain-coded signing payload from a stream of animated QR frames.
+///
+/// Unlike [AddressQrScannerSheet], which closes after a single valid
+/// scan, this sheet stays open and keeps feeding every scanned
+/// `ur:...` frame into a [BCURFountainDecoder]. The Luby-transform
+/// decoder reassembles the original message from *any sufficient subset*
+/// of frames (you do not need to catch them in order, and duplicates are
+/// harmless), so the camera just runs until `isComplete` flips true.
+///
+/// Once complete, the reconstructed [BCUR] is decoded into a
+/// [SafeTransaction] via [UrPayloadDecoder] and handed to [onComplete].
+class UrQrScannerSheet extends StatefulWidget {
+  /// True for Safe accounts < 1.0.0 (uses `dataGas` instead of `baseGas`).
+  final bool legacyJson;
+
+  /// Called with the reconstructed [SafeTransaction] once the fountain
+  /// decode succeeds. The sheet pops itself first.
+  final Function(SafeTransaction) onComplete;
+
+  const UrQrScannerSheet({
+    super.key,
+    required this.legacyJson,
+    required this.onComplete,
+  });
+
+  @override
+  State<UrQrScannerSheet> createState() => _UrQrScannerSheetState();
+}
+
+class _UrQrScannerSheetState extends State<UrQrScannerSheet>
+    with WidgetsBindingObserver {
+  final GlobalKey _qrKey = GlobalKey();
+  MobileScannerController? controller;
+  bool? cameraPermissionDenied;
+
+  late BCURFountainDecoder _decoder;
+  String _lastPart = '';
+  String? _error;
+  bool _done = false;
+  String _detectedType = '';
+
+  @override
+  void initState() {
+    _decoder = BCURFountainDecoder();
+    _permissionRequest();
+    WidgetsBinding.instance.addObserver(this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _done = true;
+    controller?.dispose();
+    super.dispose();
+  }
+
+  void _initController() {
+    controller = MobileScannerController(
+      autoStart: true,
+      formats: [BarcodeFormat.qrCode],
+    );
+    controller!.barcodes.listen(_onDetect);
+  }
+
+  Future<void> _permissionRequest() async {
+    var permissionResult = await Permission.camera.request();
+    if (permissionResult.isDenied || permissionResult.isPermanentlyDenied) {
+      cameraPermissionDenied = true;
+    } else {
+      cameraPermissionDenied = false;
+    }
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        if (cameraPermissionDenied != false) _permissionRequest();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /// Handle every barcode frame. This is the hot loop: it runs many
+  /// times per second while the animated QR cycles, so it must be cheap.
+  /// Duplicates are skipped; only `ur:` frames are accepted.
+  void _onDetect(event) {
+    if (!mounted || _done) return;
+    if (event.barcodes.isEmpty) return;
+    var raw = event.barcodes.first.rawValue ?? '';
+    if (raw.isEmpty) return;
+    // BC-UR bytewords encoding is case-insensitive; some wallets emit
+    // uppercase "UR:". Normalise to lowercase for the bc_ur library.
+    raw = raw.toLowerCase();
+    if (!raw.startsWith('ur:')) return;
+    if (raw == _lastPart) return; // dedupe the same frame held in view
+    _lastPart = raw;
+
+    try {
+      final segments = raw.substring(3).split('/');
+
+      // Single-part UR: ur:type/payload  (no seqNum-seqLength segment)
+      if (segments.length == 2) {
+        _detectedType = segments[0];
+        setState(() {});
+        _finish(BCUR.fromString(raw));
+        return;
+      }
+
+      // Multipart / fountain-coded UR: ur:type/seqNum-seqLength/fragment
+      if (segments.length != 3) return;
+      _detectedType = segments[0];
+      _decoder.receivePart(raw);
+      setState(() {}); // refresh progress UI
+
+      if (_decoder.isComplete) {
+        final result = _decoder.getResult();
+        if (result != null) {
+          _finish(result);
+        } else {
+          // Checksum / metadata mismatch — reset and keep scanning.
+          setState(() {
+            _error = 'Reconstruction failed (checksum mismatch). '
+                'Re-scan from the start of the sequence.';
+          });
+          _decoder.reset();
+          _lastPart = '';
+        }
+      }
+    } catch (e) {
+      setState(() => _error = 'Scan error: $e');
+    }
+  }
+
+  /// Decode the reconstructed UR into a SafeTransaction and finish.
+  /// On decode failure, surface the error and let the user re-scan
+  /// rather than closing the sheet.
+  void _finish(BCUR ur) {
+    if (_done) return;
+    try {
+      final tx = UrPayloadDecoder.decode(ur, legacyJson: widget.legacyJson);
+      _done = true; // stop _onDetect from processing further frames
+      Navigator.of(context).pop();
+      widget.onComplete(tx);
+    } catch (e) {
+      setState(() {
+        _error = 'Decoded a "$_detectedType" UR, but it is not a valid '
+            'Safe signing payload:\n$e';
+        _done = false;
+      });
+      _decoder.reset();
+      _lastPart = '';
+    }
+  }
+
+  void _reset() {
+    setState(() {
+      _decoder.reset();
+      _lastPart = '';
+      _error = null;
+      _detectedType = '';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: cameraPermissionDenied == null
+          ? const FittedBox(
+              fit: BoxFit.scaleDown,
+              child: CircularProgressIndicator(),
+            )
+          : cameraPermissionDenied!
+              ? _buildPermissionDenied()
+              : Builder(
+                  builder: (context) {
+                    if (controller == null) _initController();
+                    return _buildScanner();
+                  },
+                ),
+    );
+  }
+
+  Widget _buildPermissionDenied() {
+    return Container(
+      height: MediaQuery.of(context).size.height * 0.65,
+      margin: const EdgeInsets.symmetric(horizontal: 15),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.warning, size: 40, color: Colors.amber),
+          const SizedBox(height: 10),
+          const Text(
+            'Camera permission is required to scan ERC-4527 QR frames.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: () => openAppSettings(),
+            child: const Text('Open settings'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      height: MediaQuery.of(context).size.height * 0.75,
+      child: Stack(
+        children: [
+          // Camera feed — stays running the whole time.
+          MobileScanner(
+            key: _qrKey,
+            controller: controller,
+            fit: BoxFit.cover,
+          ),
+          // Scanning reticle + progress overlay.
+          _buildOverlay(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOverlay() {
+    final theme = Theme.of(context);
+    final expected = _decoder.expectedCount;
+    final received = _decoder.receivedCount;
+    final progress = _decoder.progress;
+
+    return SafeArea(
+      child: Column(
+        children: [
+          const SizedBox(height: 12),
+          // Header
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.55),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.qr_code_scanner, color: Colors.white, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _detectedType.isEmpty
+                        ? 'Point at the animated QR stream…'
+                        : 'Reconstructing "$_detectedType"',
+                    style: const TextStyle(color: Colors.white, fontSize: 14),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (expected > 0)
+                  Text(
+                    '$received / $expected',
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 13,
+                      fontFeatures: [FontFeature.tabularFigures()],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const Spacer(),
+          // Reticle
+          Center(
+            child: Container(
+              width: 240,
+              height: 240,
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: _error != null
+                      ? Colors.redAccent
+                      : theme.colorScheme.primary.withValues(alpha: 0.9),
+                  width: 2,
+                ),
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+          ),
+          const Spacer(),
+          // Progress bar + status
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.55),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (_error != null) ...[
+                  Text(
+                    _error!,
+                    style: const TextStyle(color: Colors.redAccent, fontSize: 12),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    onPressed: _reset,
+                    icon: const Icon(Icons.refresh, size: 16, color: Colors.white),
+                    label: const Text('Retry', style: TextStyle(color: Colors.white)),
+                  ),
+                ] else if (expected > 0) ...[
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: progress,
+                      backgroundColor: Colors.white24,
+                      valueColor: AlwaysStoppedAnimation(
+                        theme.colorScheme.primary.withValues(alpha: 0.9),
+                      ),
+                      minHeight: 6,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '${(progress * 100).round()}% — keep the camera steady',
+                    style: const TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ] else ...[
+                  const Text(
+                    'Waiting for first frame…',
+                    style: TextStyle(color: Colors.white70, fontSize: 12),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/ur_qr_scanner_sheet.dart
+++ b/lib/shared/widgets/ur_qr_scanner_sheet.dart
@@ -73,11 +73,7 @@ class _UrQrScannerSheetState extends State<UrQrScannerSheet>
 
   Future<void> _permissionRequest() async {
     var permissionResult = await Permission.camera.request();
-    if (permissionResult.isDenied || permissionResult.isPermanentlyDenied) {
-      cameraPermissionDenied = true;
-    } else {
-      cameraPermissionDenied = false;
-    }
+    cameraPermissionDenied = !permissionResult.isGranted;
     if (mounted) setState(() {});
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  bc_ur:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: a7b0db50f557295a1318c8ecf52ab5c6e6e81a6f
+      url: "https://github.com/ImL1s/bc-ur-dart.git"
+    source: git
+    version: "1.0.0"
   blockies:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   bc_ur:
     git:
       url: https://github.com/ImL1s/bc-ur-dart.git
+      ref: a7b0db50f557295a1318c8ecf52ab5c6e6e81a6f
   uuid: 4.5.2
   equatable: 2.0.8
   permission_handler: 12.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   http: 1.6.0
   dio: 5.9.0
   mobile_scanner: 7.1.4
+  # ERC-4527 / BC-UR fountain-code reconstruction for animated QR signing payloads
+  bc_ur:
+    git:
+      url: https://github.com/ImL1s/bc-ur-dart.git
   uuid: 4.5.2
   equatable: 2.0.8
   permission_handler: 12.0.1


### PR DESCRIPTION
I use a keycard shell as a signer on my safe, and so when signing a payload, I can get the signature via the QR stream that shows up in my wallet (ambire). The QR stream for the signing payload is a standard that works across shell, keystone, and other qr-based wallets. This PR adds a qr scanner to the manual input page, allowing people like me to use opensig much more easily, by scanning the same qr stream that we give to our signers. 

I used an agent to help me build this, and I realize that adding a library (with very few other users) for decoding the 4527 stream may carry some risk. This dep may be better to just serve as a proof of concept, and the relevant parts could be vendored as they're MIT licensed. 

I really think that this is a huge UX benefit for people using a qr-signer though, so I'd love to see something that provides the same kind of functionality get merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR scanning for ERC-4527 / BC-UR payloads when verifying a transaction, including animated and multi-part QR support.
  * Users can now populate the verification flow by scanning a QR code or via manual JSON input.
* **Bug Fixes**
  * Improved scanning error handling, including clearer permission/progress feedback and a retry path.
* **Build / Release**
  * Enhanced Android release signing configuration to load credentials only when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->